### PR TITLE
 [feat] 지역 필터링 api 구현

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -1,5 +1,6 @@
 package konkuk.corkCharge.domain.restaurant.controller;
 
+import konkuk.corkCharge.domain.restaurant.dto.request.GetFilterRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
 import konkuk.corkCharge.domain.restaurant.service.RestaurantService;
 import konkuk.corkCharge.global.response.BaseResponse;
@@ -42,6 +43,13 @@ public class RestaurantController {
     @GetMapping("/hot")
     public BaseResponse<List<GetHotRestaurantResponse>> getHotRestaurant() {
         return BaseResponse.ok(restaurantService.getHotRestaurants());
+    }
+
+    @GetMapping("/filter")
+    public BaseResponse<List<?>> filterRestaurant(
+            @ModelAttribute GetFilterRequest request
+    ) {
+        return BaseResponse.ok(restaurantService.filterRestaurants(request));
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/request/GetFilterRequest.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/request/GetFilterRequest.java
@@ -1,0 +1,10 @@
+package konkuk.corkCharge.domain.restaurant.dto.request;
+
+import java.util.List;
+
+public record GetFilterRequest(
+        String type,
+        String sido,
+        String sigungu,
+        List<String> dongList
+) { }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
@@ -14,4 +14,6 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
     List<Restaurant> findByNameContaining(String keyword);
 
     List<Restaurant> findByBookmarkCountGreaterThanEqual(int count);
+
+    List<Restaurant> findByAddressContaining(String address);
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -1,6 +1,7 @@
 package konkuk.corkCharge.domain.restaurant.service;
 
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
+import konkuk.corkCharge.domain.restaurant.dto.request.GetFilterRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
 import konkuk.corkCharge.domain.restaurant.repository.RestaurantRepository;
 import konkuk.corkCharge.global.api.naverMapsApi.NaverGeocodingClient;
@@ -13,8 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.CORKAGE_RESTAURANT_NOT_FOUND;
-import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.RESTAURANT_NOT_FOUND;
+import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -86,6 +86,48 @@ public class RestaurantService {
         return hotRestaurants.stream()
                 .map(GetHotRestaurantResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public List<?> filterRestaurants(GetFilterRequest request) {
+        List<Restaurant> matchedRestaurants = filterByAddress(request.sido(), request.sigungu(), request.dongList());
+
+        return switch (request.type()) {
+            case "hot" -> matchedRestaurants.stream()
+                    .filter(r -> r.getBookmarkCount() >= 5)
+                    .map(GetHotRestaurantResponse::from)
+                    .toList();
+
+            case "map" -> matchedRestaurants.stream()
+                    .filter(Restaurant::isHasCorkage)
+                    .map(GetSearchRestaurantResponse::from)
+                    .toList();
+
+            default -> throw new CustomException(NOT_EXIT_TYPE);
+        };
+
+    }
+
+    private List<Restaurant> filterByAddress(String sido, String sigungu, List<String> dongList) {
+        if (sido == null || sido.isBlank()) {
+            throw new CustomException(SIDO_REQUIRED);
+        }
+
+        List<Restaurant> matchedRestaurants = restaurantRepository.findByAddressContaining(sido);
+
+        if (sigungu != null && !sigungu.isBlank()) {
+            matchedRestaurants = matchedRestaurants.stream()
+                    .filter(r -> r.getAddress().contains(sigungu))
+                    .toList();
+        }
+
+        if (dongList != null && !dongList.isEmpty()) {
+            matchedRestaurants = matchedRestaurants.stream()
+                    .filter(r -> dongList.stream().anyMatch(d -> r.getAddress().contains(d)))
+                    .toList();
+        }
+
+        return matchedRestaurants;
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/konkuk/corkCharge/global/response/status/BaseExceptionResponseStatus.java
@@ -21,6 +21,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      */
     RESTAURANT_NOT_FOUND(60000, "매장 정보를 찾을 수 없습니다."),
     CORKAGE_RESTAURANT_NOT_FOUND(60001, "콜키지 매장이 없습니다."),
+    SIDO_REQUIRED(60002, "시•도 입력은 필수입니다."),
+    NOT_EXIT_TYPE(60003, "유효하지 않은 type 입니다."),
 
     /**
      * 70000 : User 도메인 에러 코드


### PR DESCRIPTION
## #️⃣연관된 이슈

#24

## 📝작업 내용

> 지역 필터링이 지금 핫한 매장과 콜키지 맵에서 적용되기에 하나의 api로 동작하도록 구현했습니다.
> 요청 데이터로 type의 값이 "hot", "map"에 따라 구분하고 그에따라 반환 타입도 다르게 구현했습니다.

콜키지 맵에서의 지역 필터링
<img width="1045" height="630" alt="스크린샷 2025-07-23 오전 2 21 33" src="https://github.com/user-attachments/assets/b8ad1e64-1a89-4e6e-9dfc-cd944ea4591b" />

지금 핫한 매장에서의 지역 필터링
<img width="1043" height="600" alt="스크린샷 2025-07-23 오전 2 23 02" src="https://github.com/user-attachments/assets/e75735f1-dffa-490a-80ef-0caec462382a" />


## 💬리뷰 요구사항(선택)
