### PR TITLE
[FEAT] 클러스터 다중 핀 상제 조회 api 개발

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -1,5 +1,6 @@
 package konkuk.corkCharge.domain.restaurant.controller;
 
+import konkuk.corkCharge.domain.restaurant.dto.request.GetClusterListRequest;
 import konkuk.corkCharge.domain.restaurant.dto.request.GetFilterRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
 import konkuk.corkCharge.domain.restaurant.service.RestaurantService;
@@ -56,6 +57,13 @@ public class RestaurantController {
             @RequestParam(name = "lonMax") double lonMax
     ) {
         return BaseResponse.ok(restaurantService.GetMapCluster(level, latMin, latMax, lonMin, lonMax));
+    }
+
+    @PostMapping("/cluster/list")
+    public BaseResponse<List<GetClusterListResponse>> getClusterRestaurantList(
+            @RequestBody GetClusterListRequest request
+    ) {
+        return BaseResponse.ok(restaurantService.getClusterList(request.restaurantIds()));
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/request/GetClusterListRequest.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/request/GetClusterListRequest.java
@@ -1,0 +1,8 @@
+package konkuk.corkCharge.domain.restaurant.dto.request;
+
+import java.util.List;
+
+public record GetClusterListRequest(
+        List<Long> restaurantIds
+) {
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetClusterListResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetClusterListResponse.java
@@ -1,0 +1,64 @@
+package konkuk.corkCharge.domain.restaurant.dto.response;
+
+import konkuk.corkCharge.domain.corkageStore.domain.CorkageStore;
+import konkuk.corkCharge.domain.corkageStore.domain.MultiCorkage;
+import konkuk.corkCharge.domain.image.domain.Image;
+import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
+
+import java.util.List;
+
+import static konkuk.corkCharge.domain.corkageStore.domain.OptionType.ETC;
+import static konkuk.corkCharge.domain.image.domain.ImageCategory.RESTAURANT;
+import static konkuk.corkCharge.domain.image.domain.ImageType.MAIN;
+
+public record GetClusterListResponse(
+        Long restaurantId,
+        String name,
+        Double rating,
+        int reviewCount,
+        String corkagePrice,
+        List<String> corkageOptions,
+        String imageUrl
+) {
+    public static GetClusterListResponse from(Restaurant restaurant) {
+        CorkageStore corkageStore = restaurant.getCorkageStore();
+
+        String corkagePrice = switch (corkageStore.getCorkageType()) {
+            case FREE -> "FREE";
+            case MULTIPLE -> {
+                int min = corkageStore.getMultiPrices().stream()
+                        .mapToInt(MultiCorkage::getPrice)
+                        .min()
+                        .orElse(Integer.MAX_VALUE);
+                yield min == Integer.MAX_VALUE ? "가격 미정" : "최저 " + min + "원";
+            }
+            case PER_BOTTLE -> "병당 " + corkageStore.getCorkagePrice() + "원";
+            case PER_PERSON -> "인당 " + corkageStore.getCorkagePrice() + "원";
+            case PER_TABLE -> "테이블당 " + corkageStore.getCorkagePrice() + "원";
+        };
+
+        List<String> corkageOptions = corkageStore.getCorkageOptions().stream()
+                .map(opt -> {
+                    if (opt.getOptionType() == ETC)
+                        return opt.getEtcContent();
+                    return opt.getOptionType().getLabel();
+                })
+                .toList();
+
+        String imageUrl = restaurant.getImages().stream()
+                .filter(img -> img.getCategory() == RESTAURANT && img.getType() == MAIN)
+                .map(Image::getImageUrl)
+                .findFirst()
+                .orElse(null);
+
+        return new GetClusterListResponse(
+                restaurant.getRestaurantId(),
+                restaurant.getName(),
+                restaurant.getRating(),
+                restaurant.getReviewCount(),
+                corkagePrice,
+                corkageOptions,
+                imageUrl
+        );
+    }
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -1,5 +1,7 @@
 package konkuk.corkCharge.domain.restaurant.service;
 
+import konkuk.corkCharge.domain.corkageStore.domain.CorkageStore;
+import konkuk.corkCharge.domain.corkageStore.domain.MultiCorkage;
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
 import konkuk.corkCharge.domain.restaurant.dto.request.GetFilterRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
@@ -140,6 +142,32 @@ public class RestaurantService {
                     .toList();
 
             default -> throw new CustomException(BAD_REQUEST);
+        };
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetClusterListResponse> getClusterList(List<Long> restaurantIds) {
+        List<Restaurant> restaurants = restaurantRepository.findAllById(restaurantIds);
+
+        return restaurants.stream()
+                .sorted((r1, r2) -> {
+                    int price1 = getComparableCorkagePrice(r1);
+                    int price2 = getComparableCorkagePrice(r2);
+                    return Integer.compare(price1, price2);
+                })
+                .map(GetClusterListResponse::from)
+                .toList();
+    }
+
+    private int getComparableCorkagePrice(Restaurant r) {
+        CorkageStore cs = r.getCorkageStore();
+
+        return switch (cs.getCorkageType()) {
+            case FREE -> 0;
+            case MULTIPLE -> cs.getMultiPrices().stream()
+                    .mapToInt(MultiCorkage::getPrice)
+                    .min().orElse(Integer.MAX_VALUE);
+            default -> cs.getCorkagePrice() != null ? cs.getCorkagePrice() : Integer.MAX_VALUE;
         };
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#57 

## 📝작업 내용

> 콜키지 맵에 클러스터 된 다중 핀 클릭 시 나오는 콜키지 가능 식당들을 콜키지 가격의 내림차순으로 정렬하여 응답하도록 구현했습니다.

<img width="1046" height="635" alt="스크린샷 2025-08-02 오후 6 15 45" src="https://github.com/user-attachments/assets/ce0073fb-15f2-4126-aa2e-cbc0ddabf367" />


## 💬리뷰 요구사항(선택)
