### PR TITLE
[FEAT] 신규 등록 매장 조회 api

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -2,7 +2,7 @@ package konkuk.corkCharge.domain.restaurant.controller;
 
 import konkuk.corkCharge.domain.restaurant.dto.request.GetClusterListRequest;
 import konkuk.corkCharge.domain.restaurant.dto.request.GetFilterRequest;
-import konkuk.corkCharge.domain.restaurant.dto.request.GetNewResaurantRequest;
+import konkuk.corkCharge.domain.restaurant.dto.request.GetNewRestaurantRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
 import konkuk.corkCharge.domain.restaurant.service.RestaurantService;
 import konkuk.corkCharge.global.response.BaseResponse;
@@ -74,7 +74,7 @@ public class RestaurantController {
 
     @GetMapping("/new")
     public BaseResponse<List<GetNewRestaurantResponse>> getNewRestaurant(
-            @RequestBody GetNewResaurantRequest request
+            @RequestBody GetNewRestaurantRequest request
             ) {
         return BaseResponse.ok(restaurantService.getNewRestaurants(request));
     }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -2,6 +2,7 @@ package konkuk.corkCharge.domain.restaurant.controller;
 
 import konkuk.corkCharge.domain.restaurant.dto.request.GetClusterListRequest;
 import konkuk.corkCharge.domain.restaurant.dto.request.GetFilterRequest;
+import konkuk.corkCharge.domain.restaurant.dto.request.GetNewResaurantRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
 import konkuk.corkCharge.domain.restaurant.service.RestaurantService;
 import konkuk.corkCharge.global.response.BaseResponse;
@@ -69,6 +70,13 @@ public class RestaurantController {
     @GetMapping("/home")
     public BaseResponse<GetHomeRestaurantResponse> getHomeRestaurant() {
         return BaseResponse.ok(restaurantService.getHomeRestaurant());
+    }
+
+    @GetMapping("/new")
+    public BaseResponse<List<GetNewRestaurantResponse>> getNewRestaurant(
+            @RequestBody GetNewResaurantRequest request
+            ) {
+        return BaseResponse.ok(restaurantService.getNewRestaurants(request));
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/NewRestaurantResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/NewRestaurantResponseMapper.java
@@ -1,0 +1,49 @@
+package konkuk.corkCharge.domain.restaurant.dto.mapper;
+
+import konkuk.corkCharge.domain.corkageStore.domain.OptionType;
+import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
+import konkuk.corkCharge.domain.restaurant.dto.response.GetNewRestaurantResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static konkuk.corkCharge.domain.corkageStore.domain.OptionType.ETC;
+
+@Component
+public class NewRestaurantResponseMapper {
+
+    public GetNewRestaurantResponse toResponse(
+            RestaurantSummary summary,
+            Double distanceKm
+    ) {
+        List<String> corkageOptions = decodeOptions(summary.getOptionBits(), summary.getOptionEtcContent());
+
+        return new GetNewRestaurantResponse(
+                summary.getRestaurantId(),
+                summary.getName(),
+                summary.getAddress(),
+                summary.getAvgRating(),
+                summary.getReviewCount() == null ? 0 : summary.getReviewCount(),
+                summary.getCorkagePrice(),
+                corkageOptions,
+                distanceKm,
+                summary.getMainImageUrl(),
+                summary.getOpeningHours()
+        );
+    }
+
+    private List<String> decodeOptions(Integer optionBits, String etcContent) {
+        if (optionBits == null || optionBits == 0)
+            return List.of();
+
+        int bits = optionBits;
+
+        return Stream.of(OptionType.values())
+                .filter(type -> (bits &  (1 << type.ordinal())) != 0)
+                .map(type -> type == ETC ? etcContent : type.getLabel())
+                .filter(opt -> opt != null && !opt.isBlank())
+                .toList();
+    }
+
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/request/GetNewResaurantRequest.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/request/GetNewResaurantRequest.java
@@ -1,0 +1,10 @@
+package konkuk.corkCharge.domain.restaurant.dto.request;
+
+public record GetNewResaurantRequest(
+        Double lat,
+        Double lon
+) {
+    public boolean hasUserLocation() {
+        return lat != null && lon != null;
+    }
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/request/GetNewRestaurantRequest.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/request/GetNewRestaurantRequest.java
@@ -1,6 +1,6 @@
 package konkuk.corkCharge.domain.restaurant.dto.request;
 
-public record GetNewResaurantRequest(
+public record GetNewRestaurantRequest(
         Double lat,
         Double lon
 ) {

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetNewRestaurantResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetNewRestaurantResponse.java
@@ -1,0 +1,17 @@
+package konkuk.corkCharge.domain.restaurant.dto.response;
+
+import java.util.List;
+
+public record GetNewRestaurantResponse(
+        Long restaurantId,
+        String restaurantName,
+        String address,
+        Double rating,
+        Integer reviewCount,
+        String corkagePrice,
+        List<String> corkageOptions,
+        Double distance,          // km기준, lat/lon 없으면 null
+        String mainImageUrls,
+        String openingHours
+) {
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/repository/NewRestaurantDistanceProjection.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/repository/NewRestaurantDistanceProjection.java
@@ -1,0 +1,7 @@
+package konkuk.corkCharge.domain.restaurant.repository;
+
+public interface NewRestaurantDistanceProjection {
+    Long getRestaurantId();
+
+    Double getDistanceKm();
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,4 +43,29 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
         WHERE (r.latitude IS NULL OR r.longitude IS NULL OR r.latitude = 0 OR r.longitude = 0)
         """)
     List<Restaurant> findRestaurantsWithoutValidCoordinates();
+
+    // lat/lon 없을 때(그냥 2주 이내 최신순 전체)
+    List<Restaurant> findByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(LocalDateTime from);
+
+    // lat/lon 있을 때: DB에서 distance(km) 계산해서 함께 반환
+    @Query(value = """
+        SELECT
+            r.restaurant_id AS restaurantId,
+            ROUND(
+                ST_Distance_Sphere(
+                    r.location,
+                    ST_SRID(POINT(:lon, :lat), 4326)
+                ) / 1000,
+                1
+            ) AS distanceKm
+        FROM restaurant r
+        WHERE r.created_at >= :from
+          AND ST_X(r.location) != 0 AND ST_Y(r.location) != 0
+        ORDER BY r.created_at DESC
+        """, nativeQuery = true)
+    List<NewRestaurantDistanceProjection> findNewRestaurantsWithDistance(
+            @Param("from") LocalDateTime from,
+            @Param("lat") double lat,
+            @Param("lon") double lon
+    );
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -9,7 +9,7 @@ import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
 import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
 import konkuk.corkCharge.domain.restaurant.dto.mapper.*;
 import konkuk.corkCharge.domain.restaurant.dto.request.GetFilterRequest;
-import konkuk.corkCharge.domain.restaurant.dto.request.GetNewResaurantRequest;
+import konkuk.corkCharge.domain.restaurant.dto.request.GetNewRestaurantRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
 import konkuk.corkCharge.domain.restaurant.repository.NewRestaurantDistanceProjection;
 import konkuk.corkCharge.domain.restaurant.repository.RestaurantRepository;
@@ -246,8 +246,8 @@ public class RestaurantService {
         );
     }
 
-    @Transactional
-    public List<GetNewRestaurantResponse> getNewRestaurants(GetNewResaurantRequest request) {
+    @Transactional(readOnly = true)
+    public List<GetNewRestaurantResponse> getNewRestaurants(GetNewRestaurantRequest request) {
         LocalDateTime from = LocalDateTime.now().minusDays(NEW_RESTAURANT_DAYS);
 
         // 사용자 좌표가 있는 경우

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -9,7 +9,9 @@ import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
 import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
 import konkuk.corkCharge.domain.restaurant.dto.mapper.*;
 import konkuk.corkCharge.domain.restaurant.dto.request.GetFilterRequest;
+import konkuk.corkCharge.domain.restaurant.dto.request.GetNewResaurantRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
+import konkuk.corkCharge.domain.restaurant.repository.NewRestaurantDistanceProjection;
 import konkuk.corkCharge.domain.restaurant.repository.RestaurantRepository;
 import konkuk.corkCharge.global.api.naverMapsApi.NaverGeocodingClient;
 import konkuk.corkCharge.global.api.naverMapsApi.dto.Address;
@@ -19,8 +21,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static konkuk.corkCharge.domain.image.domain.ImageCategory.RESTAURANT;
 import static konkuk.corkCharge.domain.image.domain.ImageType.MAIN;
@@ -29,6 +34,8 @@ import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStat
 @Service
 @RequiredArgsConstructor
 public class RestaurantService {
+
+    private static final int NEW_RESTAURANT_DAYS = 14;
 
     private final RestaurantRepository restaurantRepository;
     private final NaverGeocodingClient naverGeocodingClient;
@@ -42,6 +49,7 @@ public class RestaurantService {
     private final RestaurantListResponseMapper restaurantListResponseMapper;
 
     private final RestaurantSummaryService restaurantSummaryService;
+    private final NewRestaurantResponseMapper newRestaurantResponseMapper;
 
     @Transactional(readOnly = true)
     public List<GetRestaurantListResponse> getCorkageRestaurants() {
@@ -236,6 +244,44 @@ public class RestaurantService {
                 r.getBookmarkCount() == null ? 0 : r.getBookmarkCount(),
                 imageUrl
         );
+    }
+
+    @Transactional
+    public List<GetNewRestaurantResponse> getNewRestaurants(GetNewResaurantRequest request) {
+        LocalDateTime from = LocalDateTime.now().minusDays(NEW_RESTAURANT_DAYS);
+
+        // 사용자 좌표가 있는 경우
+        if (request.hasUserLocation()) {
+            List<NewRestaurantDistanceProjection> rows =
+                    restaurantRepository.findNewRestaurantsWithDistance(from, request.lat(), request.lon());
+
+            Map<Long, Double> distanceMap = rows.stream()
+                    .collect(Collectors.toMap(
+                            NewRestaurantDistanceProjection::getRestaurantId,
+                            NewRestaurantDistanceProjection::getDistanceKm
+                    ));
+
+            return rows.stream()
+                    .map(row -> {
+                        Long id = row.getRestaurantId();
+                        RestaurantSummary summary = restaurantSummaryService.getSummary(id);
+
+                        return newRestaurantResponseMapper.toResponse(summary, distanceMap.get(id));
+                    })
+                    .toList();
+        }
+
+        // 사용자 좌표가 없는 경우
+        List<Restaurant> restaurants = restaurantRepository.findByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(from);
+
+        return restaurants.stream()
+                .map(r -> {
+                    Long id = r.getRestaurantId();
+                    RestaurantSummary summary = restaurantSummaryService.getSummary(id);
+
+                    return newRestaurantResponseMapper.toResponse(summary, null);
+                })
+                .toList();
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantSummaryService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantSummaryService.java
@@ -33,7 +33,7 @@ public class RestaurantSummaryService {
      * cacheNames = "restaurantSummary"
      */
     @Transactional(readOnly = true)
-    @Cacheable(cacheNames = "restaurantSummary", key = "#restaurantId")
+    @Cacheable(cacheNames = "restaurantSummary", key = "#p0")
     public RestaurantSummary getSummary(Long restaurantId) {
 
         Restaurant restaurant = restaurantRepository.findById(restaurantId)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #105 

## 📝작업 내용

새로 등록된 매장(2주 안에 생성된 매장)을 조회할 수 있는 기능을 구현했습니다.
사용자의 좌표(위도, 경도)값을 기준으로 매장과의 거리를 공간 인덱스로 계산하여 응답하도록 구현했습니다.
사용자의 좌표값을 받지 않은 경우(null)에는 거리 계산을 하지 않고 2주 안에 새로 등록된 매장에 관한 정보만 반환하도록 구현했습니다.

<img width="1037" height="750" alt="스크린샷 2026-01-03 오후 11 12 46" src="https://github.com/user-attachments/assets/c9bcc71b-dfb4-4a96-a36b-cfd19541f246" />

## 💬리뷰 요구사항(선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 새로 등록된 레스토랑을 조회할 수 있는 새로운 기능 추가
  * 레스토랑명, 주소, 평점, 리뷰 수, 콜키지 요금, 콜키지 옵션, 영업시간, 이미지 등의 상세 정보 제공
  * 위치 정보 제공 시 거리 기반 필터링 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->