### PR TITLE
[FEAT] 추천 매장 조회 api 

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -94,4 +94,9 @@ public class RestaurantController {
         return BaseResponse.ok(restaurantService.getNearByRestaurants(request));
     }
 
+    @GetMapping("/recommand")
+    public BaseResponse<List<GetHomeRestaurantResponse>> getRecommandRestaurants() {
+        return BaseResponse.ok(restaurantService.getRecommandRestaurants());
+    }
+
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
@@ -122,4 +122,44 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
             @Param("lon") double lon,
             @Param("radiusMeters") int radiusMeters
     );
+
+    // 6개의 역 위치 기준 2km 이내에 있는 모든 매장 : 추천 매장 리스트
+    @Query(value = """
+        SELECT
+            r.restaurant_id AS restaurantId,
+            ROUND(
+                LEAST(
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326))
+                ) / 1000,
+                1
+            ) AS distanceKm
+        FROM restaurant r
+        WHERE r.has_corkage = 1
+          AND ST_X(r.location) != 0
+          AND ST_Y(r.location) != 0
+          AND (
+                ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326)) <= :radiusMeters
+          )
+        ORDER BY distanceKm ASC, r.bookmark_count DESC
+        """, nativeQuery = true)
+    List<RestaurantDistanceProjection> findRecommandRestaurantsWithinRadius(
+            @Param("radiusMeters") int radiusMeters,
+            @Param("gangnamLat") double gangnamLat, @Param("gangnamLon") double gangnamLon,
+            @Param("hongdaeLat") double hongdaeLat, @Param("hongdaeLon") double hongdaeLon,
+            @Param("seongsuLat") double seongsuLat, @Param("seongsuLon") double seongsuLon,
+            @Param("konkukLat") double konkukLat, @Param("konkukLon") double konkukLon,
+            @Param("itaewonLat") double itaewonLat, @Param("itaewonLon") double itaewonLon,
+            @Param("yongsanLat") double yongsanLat, @Param("yongsanLon") double yongsanLon
+    );
+
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -34,7 +34,26 @@ import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStat
 @RequiredArgsConstructor
 public class RestaurantService {
 
-    private static final int RADIUS_METERS = 3000;
+    private static final double GANGNAM_LAT = 37.498774;
+    private static final double GANGNAM_LON = 127.027829;
+
+    private static final double HONGDAE_LAT = 37.556574;
+    private static final double HONGDAE_LON = 126.923405;
+
+    private static final double SEONGSU_LAT = 37.544501;
+    private static final double SEONGSU_LON = 127.056079;
+
+    private static final double KONKUK_LAT = 37.540412;
+    private static final double KONKUK_LON = 127.069166;
+
+    private static final double ITAEWON_LAT = 37.534489;
+    private static final double ITAEWON_LON = 126.993705;
+
+    private static final double YONGSAN_LAT = 37.529764;
+    private static final double YONGSAN_LON = 126.964741;
+
+    private static final int RADIUS_METERS_RECOMMAND = 2000;
+    private static final int RADIUS_METERS_NEAR_BY = 3000;
 
     private static final Set<String> ALLOWED_CATEGORIES = Set.of(
             "중국요리",
@@ -336,7 +355,29 @@ public class RestaurantService {
         }
 
         List<RestaurantDistanceProjection> rows =
-                restaurantRepository.findNearbyRestaurantsWithinRadius(req.lat(), req.lon(), RADIUS_METERS);
+                restaurantRepository.findNearbyRestaurantsWithinRadius(req.lat(), req.lon(), RADIUS_METERS_NEAR_BY);
+
+        return rows.stream()
+                .map(row -> {
+                    Long id = row.getRestaurantId();
+                    RestaurantSummary summary = restaurantSummaryService.getSummary(id);
+                    return homeRestaurantResponseMapper.toResponse(summary, row.getDistanceKm());
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetHomeRestaurantResponse> getRecommandRestaurants() {
+        List<RestaurantDistanceProjection> rows =
+                restaurantRepository.findRecommandRestaurantsWithinRadius(
+                        RADIUS_METERS_RECOMMAND,
+                        GANGNAM_LAT, GANGNAM_LON,
+                        HONGDAE_LAT, HONGDAE_LON,
+                        SEONGSU_LAT, SEONGSU_LON,
+                        KONKUK_LAT, KONKUK_LON,
+                        ITAEWON_LAT, ITAEWON_LON,
+                        YONGSAN_LAT, YONGSAN_LON
+                );
 
         return rows.stream()
                 .map(row -> {


### PR DESCRIPTION
## #️⃣연관된 이슈

#113

## 📝작업 내용

- 현재 지정한 6개의 역(강남, 홍대, 성수, 건대, 이태원, 용산) 기준 2km 이내에 있는 매장을 조회하는 기능을 구현했습니다.

<img width="1097" height="725" alt="스크린샷 2026-01-09 오후 10 58 39" src="https://github.com/user-attachments/assets/421a5553-cbf0-4244-abee-19ed4c98169a" />


## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주요 역 위치(강남, 홍대, 성수, 건국, 이태원, 용산) 기반 레스토랑 추천 기능 추가
  * 추천 레스토랑 조회 시 거리 및 북마크 수에 따라 정렬된 결과 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->