### PR TITLE
[FEAT] 홈 화면 매장 탭 조회 api 

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/corkageStore/repository/CorkageStoreRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/corkageStore/repository/CorkageStoreRepository.java
@@ -3,6 +3,7 @@ package konkuk.corkCharge.domain.corkageStore.repository;
 import konkuk.corkCharge.domain.corkageStore.domain.CorkageStore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -20,4 +21,13 @@ public interface CorkageStoreRepository extends JpaRepository<CorkageStore, Long
     List<CorkageStore> findAllForRestaurant();
 
     Optional<CorkageStore> findByRestaurant_RestaurantId(Long restaurantId);
+
+    // redis용 bulk 메서드
+    @Query("""
+    select cs
+    from CorkageStore cs
+    join fetch cs.restaurant r
+    where r.restaurantId in :restaurantIds
+""")
+    List<CorkageStore> findAllByRestaurantIdIn(@Param("restaurantIds") List<Long> restaurantIds);
 }

--- a/src/main/java/konkuk/corkCharge/domain/image/repository/ImageRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/image/repository/ImageRepository.java
@@ -32,4 +32,24 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 """)
     List<String> findUrlsByCategoryAndTypeId(@Param("category") ImageCategory category,
                                              @Param("typeId") Long typeId);
+
+    // redis용 bulk 메서드 (매장 사진)
+    @Query("""
+    select i
+    from Image i
+    where i.category = konkuk.corkCharge.domain.image.domain.ImageCategory.RESTAURANT
+      and i.typeId in :restaurantIds
+      and i.type in (konkuk.corkCharge.domain.image.domain.ImageType.MAIN,
+                     konkuk.corkCharge.domain.image.domain.ImageType.MENU)
+""")
+    List<Image> findRestaurantImagesByRestaurantIds(@Param("restaurantIds") List<Long> restaurantIds);
+
+    // redis용 bulk 메서드 (콜키지 사진)
+    @Query("""
+    select i
+    from Image i
+    where i.category = konkuk.corkCharge.domain.image.domain.ImageCategory.CORKAGE
+      and i.typeId in :corkageIds
+""")
+    List<Image> findCorkageImagesByCorkageIds(@Param("corkageIds") List<Long> corkageIds);
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -99,7 +99,7 @@ public class RestaurantController {
         return BaseResponse.ok(restaurantService.getRecommendRestaurants());
     }
 
-    @PostMapping("/home/restaurant-tab")
+    @PostMapping("/home")
     public BaseResponse<GetRestaurantTabResponse> getHomeRestaurantTab(
             @RequestBody(required = false) UserLocationRequest request
     ) {

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -99,4 +99,11 @@ public class RestaurantController {
         return BaseResponse.ok(restaurantService.getRecommandRestaurants());
     }
 
+    @PostMapping("/home/restaurant-tab")
+    public BaseResponse<GetRestaurantTabResponse> getHomeRestaurantTab(
+            @RequestBody UserLocationRequest request
+    ) {
+        return BaseResponse.ok(restaurantService.getHomeRestaurantTab(request));
+    }
+
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -101,7 +101,7 @@ public class RestaurantController {
 
     @PostMapping("/home/restaurant-tab")
     public BaseResponse<GetRestaurantTabResponse> getHomeRestaurantTab(
-            @RequestBody UserLocationRequest request
+            @RequestBody(required = false) UserLocationRequest request
     ) {
         return BaseResponse.ok(restaurantService.getHomeRestaurantTab(request));
     }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -96,7 +96,7 @@ public class RestaurantController {
 
     @GetMapping("/recommand")
     public BaseResponse<List<GetHomeRestaurantResponse>> getRecommandRestaurants() {
-        return BaseResponse.ok(restaurantService.getRecommandRestaurants());
+        return BaseResponse.ok(restaurantService.getRecommendRestaurants());
     }
 
     @PostMapping("/home/restaurant-tab")

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/HomeRestaurantCardMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/HomeRestaurantCardMapper.java
@@ -1,0 +1,20 @@
+package konkuk.corkCharge.domain.restaurant.dto.mapper;
+
+import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
+import konkuk.corkCharge.domain.restaurant.dto.response.HomeRestaurantCard;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HomeRestaurantCardMapper {
+
+    public HomeRestaurantCard toCard(RestaurantSummary summary) {
+        return new HomeRestaurantCard(
+                summary.getRestaurantId(),
+                summary.getName(),
+                summary.getAvgRating(),
+                summary.getReviewCount() == null ? 0 : summary.getReviewCount(),
+                summary.getCorkagePrice(),
+                summary.getMainImageUrl()
+        );
+    }
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetRestaurantTabResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetRestaurantTabResponse.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 public record GetRestaurantTabResponse(
         List<HomeRestaurantCard> nearbyCard,
-        List<HomeRestaurantCard> recommandCard
+        List<HomeRestaurantCard> recommendCard
 ) {
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetRestaurantTabResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetRestaurantTabResponse.java
@@ -1,0 +1,9 @@
+package konkuk.corkCharge.domain.restaurant.dto.response;
+
+import java.util.List;
+
+public record GetRestaurantTabResponse(
+        List<HomeRestaurantCard> nearbyCard,
+        List<HomeRestaurantCard> recommandCard
+) {
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/HomeRestaurantCard.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/HomeRestaurantCard.java
@@ -1,0 +1,11 @@
+package konkuk.corkCharge.domain.restaurant.dto.response;
+
+public record HomeRestaurantCard(
+        Long restaurantId,
+        String restaurantName,
+        Double rating,
+        Integer reviewCount,
+        String corkagePrice,
+        String mainImageUrls
+) {
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
@@ -162,4 +162,74 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
             @Param("yongsanLat") double yongsanLat, @Param("yongsanLon") double yongsanLon
     );
 
+    // Home 매장 탭 top5(가까운) 매장
+    @Query(value = """
+        SELECT
+            r.restaurant_id AS restaurantId,
+            ROUND(
+                ST_Distance_Sphere(
+                    r.location,
+                    ST_SRID(POINT(:lon, :lat), 4326)
+                ) / 1000,
+                1
+            ) AS distanceKm
+        FROM restaurant r
+        WHERE r.has_corkage = 1
+          AND ST_X(r.location) != 0
+          AND ST_Y(r.location) != 0
+          AND ST_Distance_Sphere(
+                r.location,
+                ST_SRID(POINT(:lon, :lat), 4326)
+              ) <= :radiusMeters
+        ORDER BY distanceKm ASC, r.bookmark_count DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<RestaurantDistanceProjection> findNearbyRestaurantsWithinRadiusLimit(
+            @Param("lat") double lat,
+            @Param("lon") double lon,
+            @Param("radiusMeters") int radiusMeters,
+            @Param("limit") int limit
+    );
+
+    // Home 매장 탭 top5(추천) 매장
+    @Query(value = """
+        SELECT
+            r.restaurant_id AS restaurantId,
+            ROUND(
+                LEAST(
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)),
+                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326))
+                ) / 1000,
+                1
+            ) AS distanceKm
+        FROM restaurant r
+        WHERE r.has_corkage = 1
+          AND ST_X(r.location) != 0
+          AND ST_Y(r.location) != 0
+          AND (
+                ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)) <= :radiusMeters
+             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326)) <= :radiusMeters
+          )
+        ORDER BY distanceKm ASC, r.bookmark_count DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<RestaurantDistanceProjection> findRecommandRestaurantsWithinRadiusLimit(
+            @Param("radiusMeters") int radiusMeters,
+            @Param("gangnamLat") double gangnamLat, @Param("gangnamLon") double gangnamLon,
+            @Param("hongdaeLat") double hongdaeLat, @Param("hongdaeLon") double hongdaeLon,
+            @Param("seongsuLat") double seongsuLat, @Param("seongsuLon") double seongsuLon,
+            @Param("konkukLat") double konkukLat, @Param("konkukLon") double konkukLon,
+            @Param("itaewonLat") double itaewonLat, @Param("itaewonLon") double itaewonLon,
+            @Param("yongsanLat") double yongsanLat, @Param("yongsanLon") double yongsanLon,
+            @Param("limit") int limit
+    );
+
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
@@ -98,25 +98,26 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     // 사용자 위치 기준 3Km 이내에 있는 모든 매장 : 가까운 매장 리스트
     @Query(value = """
-        SELECT
-            r.restaurant_id AS restaurantId,
-            ROUND(
-                ST_Distance_Sphere(
-                    r.location,
-                    ST_SRID(POINT(:lon, :lat), 4326)
-                ) / 1000,
-                1
-            ) AS distanceKm
-        FROM restaurant r
-        WHERE r.has_corkage = 1
-          AND ST_X(r.location) != 0
-          AND ST_Y(r.location) != 0
-          AND ST_Distance_Sphere(
-                r.location,
-                ST_SRID(POINT(:lon, :lat), 4326)
-              ) <= :radiusMeters
-        ORDER BY distanceKm ASC, r.bookmark_count DESC
-        """, nativeQuery = true)
+    WITH dist AS (
+      SELECT
+        r.restaurant_id AS restaurantId,
+        r.bookmark_count AS bookmarkCount,
+        ST_Distance_Sphere(
+          r.location,
+          ST_SRID(POINT(:lon, :lat), 4326)
+        ) AS distanceMeters
+      FROM restaurant r
+      WHERE r.has_corkage = 1
+        AND ST_X(r.location) != 0
+        AND ST_Y(r.location) != 0
+    )
+    SELECT
+      restaurantId AS restaurantId,
+      ROUND(distanceMeters / 1000, 1) AS distanceKm
+    FROM dist
+    WHERE distanceMeters <= :radiusMeters
+    ORDER BY distanceMeters ASC, bookmarkCount DESC
+    """, nativeQuery = true)
     List<RestaurantDistanceProjection> findNearbyRestaurantsWithinRadius(
             @Param("lat") double lat,
             @Param("lon") double lon,
@@ -125,33 +126,30 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     // 6개의 역 위치 기준 2km 이내에 있는 모든 매장 : 추천 매장 리스트
     @Query(value = """
-        SELECT
-            r.restaurant_id AS restaurantId,
-            ROUND(
-                LEAST(
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326))
-                ) / 1000,
-                1
-            ) AS distanceKm
-        FROM restaurant r
-        WHERE r.has_corkage = 1
-          AND ST_X(r.location) != 0
-          AND ST_Y(r.location) != 0
-          AND (
-                ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326)) <= :radiusMeters
-          )
-        ORDER BY distanceKm ASC, r.bookmark_count DESC
-        """, nativeQuery = true)
+    WITH dist AS (
+      SELECT
+        r.restaurant_id AS restaurantId,
+        r.bookmark_count AS bookmarkCount,
+        LEAST(
+          ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)),
+          ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)),
+          ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)),
+          ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)),
+          ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)),
+          ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326))
+        ) AS minDistanceMeters
+      FROM restaurant r
+      WHERE r.has_corkage = 1
+        AND ST_X(r.location) != 0
+        AND ST_Y(r.location) != 0
+    )
+    SELECT
+      restaurantId,
+      ROUND(minDistanceMeters / 1000, 1) AS distanceKm
+    FROM dist
+    WHERE minDistanceMeters <= :radiusMeters
+    ORDER BY distanceKm ASC, bookmarkCount DESC
+""", nativeQuery = true)
     List<RestaurantDistanceProjection> findRecommendRestaurantsWithinRadius(
             @Param("radiusMeters") int radiusMeters,
             @Param("gangnamLat") double gangnamLat, @Param("gangnamLon") double gangnamLon,
@@ -164,21 +162,23 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     // Home 매장 탭 top5(가까운) 매장
     @Query(value = """
-    SELECT r.restaurant_id
-    FROM restaurant r
-    WHERE r.has_corkage = 1
-      AND ST_X(r.location) != 0
-      AND ST_Y(r.location) != 0
-      AND ST_Distance_Sphere(
-            r.location,
-            ST_SRID(POINT(:lon, :lat), 4326)
-          ) <= :radiusMeters
-    ORDER BY
-      ST_Distance_Sphere(
-        r.location,
-        ST_SRID(POINT(:lon, :lat), 4326)
-      ) ASC,
-      r.bookmark_count DESC
+    WITH dist AS (
+      SELECT
+        r.restaurant_id AS restaurantId,
+        r.bookmark_count AS bookmarkCount,
+        ST_Distance_Sphere(
+          r.location,
+          ST_SRID(POINT(:lon, :lat), 4326)
+        ) AS distanceMeters
+      FROM restaurant r
+      WHERE r.has_corkage = 1
+        AND ST_X(r.location) != 0
+        AND ST_Y(r.location) != 0
+    )
+    SELECT restaurantId
+    FROM dist
+    WHERE distanceMeters <= :radiusMeters
+    ORDER BY distanceMeters ASC, bookmarkCount DESC
     LIMIT :limit
     """, nativeQuery = true)
     List<Long> findNearbyRestaurantIdsWithinRadiusLimit(
@@ -190,30 +190,29 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     // Home 매장 탭 top5(추천) 매장
     @Query(value = """
-    SELECT r.restaurant_id
-    FROM restaurant r
-    WHERE r.has_corkage = 1
-      AND ST_X(r.location) != 0
-      AND ST_Y(r.location) != 0
-      AND (
-            ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)) <= :radiusMeters
-         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)) <= :radiusMeters
-         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)) <= :radiusMeters
-         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)) <= :radiusMeters
-         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)) <= :radiusMeters
-         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326)) <= :radiusMeters
-      )
-    ORDER BY
-      LEAST(
-        ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)),
-        ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)),
-        ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)),
-        ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)),
-        ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)),
-        ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326))
-      ) ASC,
-      r.bookmark_count DESC
-    LIMIT :limit
+    WITH distance_calc AS (
+        SELECT
+            r.restaurant_id,
+            r.bookmark_count,
+            LEAST(
+                ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)),
+                ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)),
+                ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)),
+                ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)),
+                ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)),
+                ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326))
+            ) AS min_distance
+        FROM restaurant r
+        WHERE r.has_corkage = 1
+          AND ST_X(r.location) != 0
+          AND ST_Y(r.location) != 0
+    )
+    SELECT
+        restaurant_id
+    FROM distance_calc
+    WHERE min_distance <= :radiusMeters
+    ORDER BY min_distance ASC, bookmark_count DESC
+    LIMIT :limit;
     """, nativeQuery = true)
     List<Long> findRecommendRestaurantIdsWithinRadiusLimit(
             @Param("radiusMeters") int radiusMeters,

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
@@ -164,27 +164,24 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     // Home 매장 탭 top5(가까운) 매장
     @Query(value = """
-        SELECT
-            r.restaurant_id AS restaurantId,
-            ROUND(
-                ST_Distance_Sphere(
-                    r.location,
-                    ST_SRID(POINT(:lon, :lat), 4326)
-                ) / 1000,
-                1
-            ) AS distanceKm
-        FROM restaurant r
-        WHERE r.has_corkage = 1
-          AND ST_X(r.location) != 0
-          AND ST_Y(r.location) != 0
-          AND ST_Distance_Sphere(
-                r.location,
-                ST_SRID(POINT(:lon, :lat), 4326)
-              ) <= :radiusMeters
-        ORDER BY distanceKm ASC, r.bookmark_count DESC
-        LIMIT :limit
-        """, nativeQuery = true)
-    List<RestaurantDistanceProjection> findNearbyRestaurantsWithinRadiusLimit(
+    SELECT r.restaurant_id
+    FROM restaurant r
+    WHERE r.has_corkage = 1
+      AND ST_X(r.location) != 0
+      AND ST_Y(r.location) != 0
+      AND ST_Distance_Sphere(
+            r.location,
+            ST_SRID(POINT(:lon, :lat), 4326)
+          ) <= :radiusMeters
+    ORDER BY
+      ST_Distance_Sphere(
+        r.location,
+        ST_SRID(POINT(:lon, :lat), 4326)
+      ) ASC,
+      r.bookmark_count DESC
+    LIMIT :limit
+    """, nativeQuery = true)
+    List<Long> findNearbyRestaurantIdsWithinRadiusLimit(
             @Param("lat") double lat,
             @Param("lon") double lon,
             @Param("radiusMeters") int radiusMeters,
@@ -193,35 +190,32 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     // Home 매장 탭 top5(추천) 매장
     @Query(value = """
-        SELECT
-            r.restaurant_id AS restaurantId,
-            ROUND(
-                LEAST(
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)),
-                    ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326))
-                ) / 1000,
-                1
-            ) AS distanceKm
-        FROM restaurant r
-        WHERE r.has_corkage = 1
-          AND ST_X(r.location) != 0
-          AND ST_Y(r.location) != 0
-          AND (
-                ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)) <= :radiusMeters
-             OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326)) <= :radiusMeters
-          )
-        ORDER BY distanceKm ASC, r.bookmark_count DESC
-        LIMIT :limit
-        """, nativeQuery = true)
-    List<RestaurantDistanceProjection> findRecommendRestaurantsWithinRadiusLimit(
+    SELECT r.restaurant_id
+    FROM restaurant r
+    WHERE r.has_corkage = 1
+      AND ST_X(r.location) != 0
+      AND ST_Y(r.location) != 0
+      AND (
+            ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)) <= :radiusMeters
+         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)) <= :radiusMeters
+         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)) <= :radiusMeters
+         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)) <= :radiusMeters
+         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)) <= :radiusMeters
+         OR ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326)) <= :radiusMeters
+      )
+    ORDER BY
+      LEAST(
+        ST_Distance_Sphere(r.location, ST_SRID(POINT(:gangnamLon, :gangnamLat), 4326)),
+        ST_Distance_Sphere(r.location, ST_SRID(POINT(:hongdaeLon, :hongdaeLat), 4326)),
+        ST_Distance_Sphere(r.location, ST_SRID(POINT(:seongsuLon, :seongsuLat), 4326)),
+        ST_Distance_Sphere(r.location, ST_SRID(POINT(:konkukLon, :konkukLat), 4326)),
+        ST_Distance_Sphere(r.location, ST_SRID(POINT(:itaewonLon, :itaewonLat), 4326)),
+        ST_Distance_Sphere(r.location, ST_SRID(POINT(:yongsanLon, :yongsanLat), 4326))
+      ) ASC,
+      r.bookmark_count DESC
+    LIMIT :limit
+    """, nativeQuery = true)
+    List<Long> findRecommendRestaurantIdsWithinRadiusLimit(
             @Param("radiusMeters") int radiusMeters,
             @Param("gangnamLat") double gangnamLat, @Param("gangnamLon") double gangnamLon,
             @Param("hongdaeLat") double hongdaeLat, @Param("hongdaeLon") double hongdaeLon,

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
@@ -152,7 +152,7 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
           )
         ORDER BY distanceKm ASC, r.bookmark_count DESC
         """, nativeQuery = true)
-    List<RestaurantDistanceProjection> findRecommandRestaurantsWithinRadius(
+    List<RestaurantDistanceProjection> findRecommendRestaurantsWithinRadius(
             @Param("radiusMeters") int radiusMeters,
             @Param("gangnamLat") double gangnamLat, @Param("gangnamLon") double gangnamLon,
             @Param("hongdaeLat") double hongdaeLat, @Param("hongdaeLon") double hongdaeLon,
@@ -221,7 +221,7 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
         ORDER BY distanceKm ASC, r.bookmark_count DESC
         LIMIT :limit
         """, nativeQuery = true)
-    List<RestaurantDistanceProjection> findRecommandRestaurantsWithinRadiusLimit(
+    List<RestaurantDistanceProjection> findRecommendRestaurantsWithinRadiusLimit(
             @Param("radiusMeters") int radiusMeters,
             @Param("gangnamLat") double gangnamLat, @Param("gangnamLon") double gangnamLon,
             @Param("hongdaeLat") double hongdaeLat, @Param("hongdaeLon") double hongdaeLon,

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -75,6 +75,7 @@ public class RestaurantService {
     private final HotRestaurantResponseMapper hotRestaurantResponseMapper;
     private final MapRestaurantResponseMapper mapRestaurantResponseMapper;
     private final RestaurantListResponseMapper restaurantListResponseMapper;
+    private final HomeRestaurantCardMapper homeRestaurantCardMapper;
 
     private final RestaurantSummaryService restaurantSummaryService;
     private final HomeRestaurantResponseMapper homeRestaurantResponseMapper;
@@ -386,6 +387,46 @@ public class RestaurantService {
                     return homeRestaurantResponseMapper.toResponse(summary, row.getDistanceKm());
                 })
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public GetRestaurantTabResponse getHomeRestaurantTab(UserLocationRequest req) {
+        final int LIMIT = 5;
+
+        // 가까운 매장 top5
+        if (req == null || !req.hasUserLocation()) {
+            throw new CustomException(LOCATION_REQUIRED);
+        }
+
+        List<RestaurantDistanceProjection> nearbyRows =
+                restaurantRepository.findNearbyRestaurantsWithinRadiusLimit(
+                        req.lat(), req.lon(), RADIUS_METERS_NEAR_BY, LIMIT
+                );
+
+        List<HomeRestaurantCard> nearbyCard = nearbyRows.stream()
+                .map(row -> restaurantSummaryService.getSummary(row.getRestaurantId()))
+                .map(homeRestaurantCardMapper::toCard)
+                .toList();
+
+        // 추천 매장 top5
+        List<RestaurantDistanceProjection> recommandRows =
+                restaurantRepository.findRecommandRestaurantsWithinRadiusLimit(
+                        RADIUS_METERS_RECOMMAND,
+                        GANGNAM_LAT, GANGNAM_LON,
+                        HONGDAE_LAT, HONGDAE_LON,
+                        SEONGSU_LAT, SEONGSU_LON,
+                        KONKUK_LAT, KONKUK_LON,
+                        ITAEWON_LAT, ITAEWON_LON,
+                        YONGSAN_LAT, YONGSAN_LON,
+                        LIMIT
+                );
+
+        List<HomeRestaurantCard> recommandCard = recommandRows.stream()
+                .map(row -> restaurantSummaryService.getSummary(row.getRestaurantId()))
+                .map(homeRestaurantCardMapper::toCard)
+                .toList();
+
+        return new GetRestaurantTabResponse(nearbyCard, recommandCard);
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -52,7 +52,7 @@ public class RestaurantService {
     private static final double YONGSAN_LAT = 37.529764;
     private static final double YONGSAN_LON = 126.964741;
 
-    private static final int RADIUS_METERS_RECOMMAND = 2000;
+    private static final int RADIUS_METERS_RECOMMEND = 2000;
     private static final int RADIUS_METERS_NEAR_BY = 3000;
 
     private static final Set<String> ALLOWED_CATEGORIES = Set.of(
@@ -368,10 +368,10 @@ public class RestaurantService {
     }
 
     @Transactional(readOnly = true)
-    public List<GetHomeRestaurantResponse> getRecommandRestaurants() {
+    public List<GetHomeRestaurantResponse> getRecommendRestaurants() {
         List<RestaurantDistanceProjection> rows =
-                restaurantRepository.findRecommandRestaurantsWithinRadius(
-                        RADIUS_METERS_RECOMMAND,
+                restaurantRepository.findRecommendRestaurantsWithinRadius(
+                        RADIUS_METERS_RECOMMEND,
                         GANGNAM_LAT, GANGNAM_LON,
                         HONGDAE_LAT, HONGDAE_LON,
                         SEONGSU_LAT, SEONGSU_LON,
@@ -409,9 +409,9 @@ public class RestaurantService {
                 .toList();
 
         // 추천 매장 top5
-        List<RestaurantDistanceProjection> recommandRows =
-                restaurantRepository.findRecommandRestaurantsWithinRadiusLimit(
-                        RADIUS_METERS_RECOMMAND,
+        List<RestaurantDistanceProjection> recommendRows =
+                restaurantRepository.findRecommendRestaurantsWithinRadiusLimit(
+                        RADIUS_METERS_RECOMMEND,
                         GANGNAM_LAT, GANGNAM_LON,
                         HONGDAE_LAT, HONGDAE_LON,
                         SEONGSU_LAT, SEONGSU_LON,
@@ -421,12 +421,12 @@ public class RestaurantService {
                         LIMIT
                 );
 
-        List<HomeRestaurantCard> recommandCard = recommandRows.stream()
+        List<HomeRestaurantCard> recommendCard = recommendRows.stream()
                 .map(row -> restaurantSummaryService.getSummary(row.getRestaurantId()))
                 .map(homeRestaurantCardMapper::toCard)
                 .toList();
 
-        return new GetRestaurantTabResponse(nearbyCard, recommandCard);
+        return new GetRestaurantTabResponse(nearbyCard, recommendCard);
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -394,19 +394,20 @@ public class RestaurantService {
         final int LIMIT = 5;
 
         // 가까운 매장 top5
+        List<HomeRestaurantCard> nearbyCard;
         if (req == null || !req.hasUserLocation()) {
-            throw new CustomException(LOCATION_REQUIRED);
+            nearbyCard = List.of();
+        } else {
+            List<RestaurantDistanceProjection> nearbyRows =
+                    restaurantRepository.findNearbyRestaurantsWithinRadiusLimit(
+                            req.lat(), req.lon(), RADIUS_METERS_NEAR_BY, LIMIT
+                    );
+
+            nearbyCard = nearbyRows.stream()
+                    .map(row -> restaurantSummaryService.getSummary(row.getRestaurantId()))
+                    .map(homeRestaurantCardMapper::toCard)
+                    .toList();
         }
-
-        List<RestaurantDistanceProjection> nearbyRows =
-                restaurantRepository.findNearbyRestaurantsWithinRadiusLimit(
-                        req.lat(), req.lon(), RADIUS_METERS_NEAR_BY, LIMIT
-                );
-
-        List<HomeRestaurantCard> nearbyCard = nearbyRows.stream()
-                .map(row -> restaurantSummaryService.getSummary(row.getRestaurantId()))
-                .map(homeRestaurantCardMapper::toCard)
-                .toList();
 
         // 추천 매장 top5
         List<RestaurantDistanceProjection> recommendRows =

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -394,19 +394,19 @@ public class RestaurantService {
         final int LIMIT = 5;
 
         // 가까운 매장 top5
-        List<HomeRestaurantCard> nearbyCard;
+        List<Long> nearbyIds;
         if (req == null || !req.hasUserLocation()) {
-            nearbyCard = List.of();
+            nearbyIds = List.of();
         } else {
-            List<Long> nearbyIds =
+            nearbyIds =
                     restaurantRepository.findNearbyRestaurantIdsWithinRadiusLimit(
                             req.lat(), req.lon(), RADIUS_METERS_NEAR_BY, LIMIT
                     );
 
-            nearbyCard = nearbyIds.stream()
-                    .map(restaurantSummaryService::getSummary)
-                    .map(homeRestaurantCardMapper::toCard)
-                    .toList();
+//            nearbyCard = nearbyIds.stream()
+//                    .map(restaurantSummaryService::getSummary)
+//                    .map(homeRestaurantCardMapper::toCard)
+//                    .toList();
         }
 
         // 추천 매장 top5
@@ -422,8 +422,16 @@ public class RestaurantService {
                         LIMIT
                 );
 
-        List<HomeRestaurantCard> recommendCard = recommendIds.stream()
-                .map(restaurantSummaryService::getSummary)
+//        List<HomeRestaurantCard> recommendCard = recommendIds.stream()
+//                .map(restaurantSummaryService::getSummary)
+//                .map(homeRestaurantCardMapper::toCard)
+//                .toList();
+
+        List<HomeRestaurantCard> nearbyCard = restaurantSummaryService.getSummariesInOrder(nearbyIds).stream()
+                .map(homeRestaurantCardMapper::toCard)
+                .toList();
+
+        List<HomeRestaurantCard> recommendCard = restaurantSummaryService.getSummariesInOrder(recommendIds).stream()
                 .map(homeRestaurantCardMapper::toCard)
                 .toList();
 

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -398,20 +398,20 @@ public class RestaurantService {
         if (req == null || !req.hasUserLocation()) {
             nearbyCard = List.of();
         } else {
-            List<RestaurantDistanceProjection> nearbyRows =
-                    restaurantRepository.findNearbyRestaurantsWithinRadiusLimit(
+            List<Long> nearbyIds =
+                    restaurantRepository.findNearbyRestaurantIdsWithinRadiusLimit(
                             req.lat(), req.lon(), RADIUS_METERS_NEAR_BY, LIMIT
                     );
 
-            nearbyCard = nearbyRows.stream()
-                    .map(row -> restaurantSummaryService.getSummary(row.getRestaurantId()))
+            nearbyCard = nearbyIds.stream()
+                    .map(restaurantSummaryService::getSummary)
                     .map(homeRestaurantCardMapper::toCard)
                     .toList();
         }
 
         // 추천 매장 top5
-        List<RestaurantDistanceProjection> recommendRows =
-                restaurantRepository.findRecommendRestaurantsWithinRadiusLimit(
+        List<Long> recommendIds =
+                restaurantRepository.findRecommendRestaurantIdsWithinRadiusLimit(
                         RADIUS_METERS_RECOMMEND,
                         GANGNAM_LAT, GANGNAM_LON,
                         HONGDAE_LAT, HONGDAE_LON,
@@ -422,8 +422,8 @@ public class RestaurantService {
                         LIMIT
                 );
 
-        List<HomeRestaurantCard> recommendCard = recommendRows.stream()
-                .map(row -> restaurantSummaryService.getSummary(row.getRestaurantId()))
+        List<HomeRestaurantCard> recommendCard = recommendIds.stream()
+                .map(restaurantSummaryService::getSummary)
                 .map(homeRestaurantCardMapper::toCard)
                 .toList();
 

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantSummaryService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantSummaryService.java
@@ -17,6 +17,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.*;
@@ -27,6 +28,7 @@ public class RestaurantSummaryService {
     private final RestaurantRepository restaurantRepository;
     private final CorkageStoreRepository corkageStoreRepository;
     private final ImageRepository imageRepository;
+
 
     /**
      * 레스토랑 요약 정보를 Redis에 캐싱.
@@ -67,7 +69,7 @@ public class RestaurantSummaryService {
 
             // pairing 이미지
             pairingImageUrl = imageRepository
-                    .findFirstByCategoryAndTypeIdAndType(ImageCategory.CORKAGE, corkage.getCorkageStoreId(), ImageType.MAIN)
+                    .findFirstByCategoryAndTypeId(ImageCategory.CORKAGE, corkage.getCorkageStoreId())
                     .map(Image::getImageUrl)
                     .orElse(null);
 
@@ -134,6 +136,125 @@ public class RestaurantSummaryService {
                 .latitude(restaurant.getLatitude())
                 .longitude(restaurant.getLongitude())
 
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<RestaurantSummary> getSummariesInOrder(List<Long> restaurantIds) {
+        if (restaurantIds == null || restaurantIds.isEmpty()) return List.of();
+
+        // 1) Restaurant bulk
+        List<Restaurant> restaurants = restaurantRepository.findAllById(restaurantIds);
+        Map<Long, Restaurant> restaurantMap = restaurants.stream()
+                .collect(Collectors.toMap(Restaurant::getRestaurantId, r -> r));
+
+        // 2) CorkageStore bulk
+        List<CorkageStore> corkageStores = corkageStoreRepository.findAllByRestaurantIdIn(restaurantIds);
+        Map<Long, CorkageStore> corkageMap = corkageStores.stream()
+                .collect(Collectors.toMap(cs -> cs.getRestaurant().getRestaurantId(), cs -> cs));
+
+        // 3) RESTAURANT 이미지
+        List<Image> restaurantImages = imageRepository.findRestaurantImagesByRestaurantIds(restaurantIds);
+
+        Map<Long, String> mainImageMap = new HashMap<>();
+        Map<Long, String> menuImageMap = new HashMap<>();
+        for (Image img : restaurantImages) {
+            if (img.getType() == ImageType.MAIN) mainImageMap.putIfAbsent(img.getTypeId(), img.getImageUrl());
+            if (img.getType() == ImageType.MENU) menuImageMap.putIfAbsent(img.getTypeId(), img.getImageUrl());
+        }
+
+        // 4) CORKAGE 이미지
+        List<Long> corkageIds = corkageStores.stream()
+                .map(CorkageStore::getCorkageStoreId)
+                .toList();
+
+        Map<Long, String> corkageImageMap = new HashMap<>();
+        if (!corkageIds.isEmpty()) {
+            List<Image> corkageImages = imageRepository.findCorkageImagesByCorkageIds(corkageIds);
+            for (Image img : corkageImages) {
+                // typeId = corkageStoreId
+                corkageImageMap.putIfAbsent(img.getTypeId(), img.getImageUrl());
+            }
+        }
+
+        // 5) 순서 유지
+        List<RestaurantSummary> result = new ArrayList<>(restaurantIds.size());
+        for (Long id : restaurantIds) {
+            Restaurant restaurant = restaurantMap.get(id);
+            if (restaurant == null) continue;
+
+            CorkageStore corkage = corkageMap.get(id);
+
+            String main = mainImageMap.get(id);
+            String menu = menuImageMap.get(id);
+            String pairing = (corkage == null) ? null : corkageImageMap.get(corkage.getCorkageStoreId());
+
+            result.add(buildSummary(restaurant, corkage, main, menu, pairing));
+        }
+
+        return result;
+    }
+
+    private RestaurantSummary buildSummary(
+            Restaurant restaurant,
+            CorkageStore corkage,
+            String mainImageUrl,
+            String menuImageUrl,
+            String pairingImageUrl
+    ) {
+        String corkagePrice = null;
+        Integer optionBits = null;
+        String optionEtcContent = null;
+        String pairingAlcohol = null;
+        String pairingDescription = null;
+        CorkageType corkageType = null;
+
+        if (corkage != null) {
+            corkageType = corkage.getCorkageType();
+
+            if (corkageType == CorkageType.MULTIPLE) {
+                corkagePrice = corkage.getMultiPrices().stream()
+                        .map(mp -> mp.getLiquorType() + " 병당: " + mp.getPrice() + "원")
+                        .collect(Collectors.joining(", "));
+            } else if (corkageType == CorkageType.FREE) {
+                corkagePrice = "콜키지 프리";
+            } else {
+                corkagePrice = switch (corkageType) {
+                    case PER_BOTTLE -> "병당 " + corkage.getCorkagePrice() + "원";
+                    case PER_PERSON -> "인당 " + corkage.getCorkagePrice() + "원";
+                    case PER_TABLE -> "테이블당 " + corkage.getCorkagePrice() + "원";
+                    default -> null;
+                };
+            }
+
+            optionBits = corkage.getOptionBits();
+            optionEtcContent = corkage.getEtcContent();
+            pairingAlcohol = corkage.getPairing();
+            pairingDescription = corkage.getDescription();
+        }
+
+        return RestaurantSummary.builder()
+                .restaurantId(restaurant.getRestaurantId())
+                .name(restaurant.getName())
+                .address(restaurant.getAddress())
+                .phone(restaurant.getPhone())
+                .representMenu(restaurant.getRepresentMenu())
+                .openingHours(restaurant.getOpeningHours())
+                .mainImageUrl(mainImageUrl)
+                .menuImageUrl(menuImageUrl)
+                .pairingImageUrl(pairingImageUrl)
+                .reviewCount(restaurant.getReviewCount())
+                .avgRating(restaurant.getRating())
+                .bookmarkCount(restaurant.getBookmarkCount())
+                .hasCorkage(restaurant.isHasCorkage())
+                .corkageType(corkageType)
+                .corkagePrice(corkagePrice)
+                .optionBits(optionBits)
+                .optionEtcContent(optionEtcContent)
+                .pairingAlcohol(pairingAlcohol)
+                .pairingDescription(pairingDescription)
+                .latitude(restaurant.getLatitude())
+                .longitude(restaurant.getLongitude())
                 .build();
     }
 

--- a/src/main/java/konkuk/corkCharge/global/config/SecurityConfig.java
+++ b/src/main/java/konkuk/corkCharge/global/config/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig {
                                 "/tips",
                                 "/restaurants/new",
                                 "/restaurants/category",
-                                "/restaurants/nearby")
+                                "/restaurants/nearby",
+                                "/restaurants/home/restaurant-tab")
                         .permitAll()
 
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/src/main/java/konkuk/corkCharge/global/config/SecurityConfig.java
+++ b/src/main/java/konkuk/corkCharge/global/config/SecurityConfig.java
@@ -41,7 +41,6 @@ public class SecurityConfig {
                                 "/restaurants/search",
                                 "/restaurants/filter",
                                 "/restaurants/map",
-                                "/restaurants/home",
                                 "/reviews/corkageScore",
                                 "/tips",
                                 "/tips/*")
@@ -54,7 +53,7 @@ public class SecurityConfig {
                                 "/restaurants/new",
                                 "/restaurants/category",
                                 "/restaurants/nearby",
-                                "/restaurants/home/restaurant-tab")
+                                "/restaurants/home")
                         .permitAll()
 
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()


### PR DESCRIPTION
## #️⃣연관된 이슈

#115 

## 📝작업 내용
- 홈 화면에서 매장 탭 클릭 시 가까운/추천 top5 매장을 조회할 수 있는 기능을 구현했습니다.

<img width="1098" height="728" alt="스크린샷 2026-01-10 오후 3 36 19" src="https://github.com/user-attachments/assets/d81a84cf-2499-4dc9-8544-3987d6221f63" />
<img width="1107" height="450" alt="스크린샷 2026-01-10 오후 3 36 40" src="https://github.com/user-attachments/assets/0756688d-95a2-4412-8d1f-00d9e1a490df" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈 탭에 위치 기반 음식점 카드 추가: 근처 5개 및 추천 5개 카드(이름, 평점, 리뷰 수, 콜키지 가격, 대표 이미지).
  * 홈 탭용 POST 엔드포인트 추가로 위치(optional) 전달 시 탭 데이터 반환 지원.

* **개선**
  * 음식점 요약 및 이미지·콜키지 정보 일괄 조회 추가로 카드 로드 일관성 및 성능 향상.
  * 추천/근처 조회에 결과 수 제어와 거리 기반 정렬 개선.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->