### PR TITLE
[FEAT] 콜키지맵 저장한 매장 그룹별 핀 조회 api

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/bookmark/repository/GroupRestaurantPinProjection.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/repository/GroupRestaurantPinProjection.java
@@ -1,0 +1,21 @@
+package konkuk.corkCharge.domain.bookmark.repository;
+
+import konkuk.corkCharge.domain.bookmark.domain.BookmarkGroupVisibility;
+
+public interface GroupRestaurantPinProjection {
+    Long getGroupId();
+
+    Integer getDisplayOrder();
+
+    String getName();
+
+    String getColor();
+
+    BookmarkGroupVisibility getVisibility();
+
+    Long getRestaurantId();
+
+    Double getLatitude();
+
+    Double getLongitude();
+}

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/repository/RestaurantBookmarkGroupItemRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/repository/RestaurantBookmarkGroupItemRepository.java
@@ -3,6 +3,8 @@ package konkuk.corkCharge.domain.bookmark.repository;
 import konkuk.corkCharge.domain.bookmark.domain.Bookmark;
 import konkuk.corkCharge.domain.bookmark.domain.RestaurantBookmarkGroupItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,4 +16,34 @@ public interface RestaurantBookmarkGroupItemRepository extends JpaRepository<Res
     void deleteAllByGroup_Id(Long groupId);
     int countByGroup_Id(Long groupId);
     boolean existsByBookmark_IdAndGroup_Id(Long bookmarkId, Long groupId);
+
+    // 사용자가 저장한 콜키지 매장들 중 현재 화면 안에 있는 핀들을 그룹별로 가져옴
+    @Query(value = """
+    SELECT
+        g.restaurant_bookmark_group_id AS groupId,
+        g.name AS name,
+        g.color AS color,
+        g.visibility AS visibility,
+        r.restaurant_id AS restaurantId,
+        r.latitude AS latitude,
+        r.longitude AS longitude
+    FROM restaurant_bookmark_group_item gi
+      JOIN restaurant_bookmark_group g
+        ON gi.restaurant_bookmark_group_id = g.restaurant_bookmark_group_id
+      JOIN bookmark b
+        ON gi.bookmark_id = b.bookmark_id
+      JOIN restaurant r
+        ON b.target_id = r.restaurant_id
+    WHERE g.user_id = :userId
+      AND b.target_type = 'RESTAURANT'
+      AND r.has_corkage = 1
+      AND ST_Within(r.location, ST_GeomFromText(:wktPolygon, 4326))
+      AND ST_X(r.location) != 0
+      AND ST_Y(r.location) != 0
+    ORDER BY g.display_order ASC, gi.created_at DESC, r.restaurant_id DESC
+    """, nativeQuery = true)
+    List<GroupRestaurantPinProjection> findGroupRestaurantPinsInBounds(
+            @Param("userId") Long userId,
+            @Param("wktPolygon") String wktPolygon
+    );
 }

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/repository/RestaurantBookmarkGroupRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/repository/RestaurantBookmarkGroupRepository.java
@@ -3,6 +3,7 @@ package konkuk.corkCharge.domain.bookmark.repository;
 import konkuk.corkCharge.domain.bookmark.domain.RestaurantBookmarkGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -16,5 +17,5 @@ public interface RestaurantBookmarkGroupRepository extends JpaRepository<Restaur
     from RestaurantBookmarkGroup g
     where g.user.userId = :userId
     """)
-    int findMaxDisplayOrderByUserId(Long userId);
+    int findMaxDisplayOrderByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -6,6 +6,7 @@ import konkuk.corkCharge.domain.restaurant.dto.request.GetFilterRequest;
 import konkuk.corkCharge.domain.restaurant.dto.request.UserLocationRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
 import konkuk.corkCharge.domain.restaurant.service.RestaurantService;
+import konkuk.corkCharge.global.annotation.LoginUserId;
 import konkuk.corkCharge.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -38,11 +39,6 @@ public class RestaurantController {
         return BaseResponse.ok(restaurantService.searchRestaurants(keyword));
     }
 
-//    @GetMapping("/hot")
-//    public BaseResponse<List<GetHotRestaurantResponse>> getHotRestaurant() {
-//        return BaseResponse.ok(restaurantService.getHotRestaurants());
-//    }
-
     @GetMapping("/filter")
     public BaseResponse<List<?>> filterRestaurant(
             @ModelAttribute GetFilterRequest request
@@ -67,11 +63,6 @@ public class RestaurantController {
     ) {
         return BaseResponse.ok(restaurantService.getClusterList(request.restaurantIds()));
     }
-
-//    @GetMapping("/home")
-//    public BaseResponse<GetHomeRestaurantResponse> getHomeRestaurant() {
-//        return BaseResponse.ok(restaurantService.getHomeRestaurant());
-//    }
 
     @PostMapping("/new")
     public BaseResponse<List<GetHomeRestaurantResponse>> getNewRestaurant(
@@ -104,6 +95,17 @@ public class RestaurantController {
             @RequestBody(required = false) UserLocationRequest request
     ) {
         return BaseResponse.ok(restaurantService.getHomeRestaurantTab(request));
+    }
+
+    @GetMapping("/map/group")
+    public BaseResponse<GetGroupRestaurantPinsResponse> getGroupRestaurantPins(
+            @LoginUserId Long userId,
+            @RequestParam(name = "latMin") double latMin,
+            @RequestParam(name = "latMax") double latMax,
+            @RequestParam(name = "lonMin") double lonMin,
+            @RequestParam(name = "lonMax") double lonMax
+    ) {
+        return BaseResponse.ok(restaurantService.getGroupRestaurantPins(userId, latMin, latMax, lonMin, lonMax));
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetGroupRestaurantPinsResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetGroupRestaurantPinsResponse.java
@@ -1,0 +1,25 @@
+package konkuk.corkCharge.domain.restaurant.dto.response;
+
+import konkuk.corkCharge.domain.bookmark.domain.BookmarkGroupVisibility;
+
+import java.util.List;
+
+public record GetGroupRestaurantPinsResponse(
+        int totalGroupCount,
+        List<GroupPins> groups
+) {
+    public record GroupPins(
+       Long groupId,
+       String name,
+       String color,
+       BookmarkGroupVisibility visibility,
+       int storeCount,
+       List<Pin> pins
+    ) {}
+
+    public record Pin(
+       Long restaurantId,
+       Double lat,
+       Double lon
+    ) {}
+}

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -1,9 +1,11 @@
 package konkuk.corkCharge.domain.restaurant.service;
 
+import konkuk.corkCharge.domain.bookmark.domain.BookmarkGroupVisibility;
+import konkuk.corkCharge.domain.bookmark.repository.GroupRestaurantPinProjection;
+import konkuk.corkCharge.domain.bookmark.repository.RestaurantBookmarkGroupItemRepository;
 import konkuk.corkCharge.domain.corkageStore.repository.CorkageStoreRepository;
 import konkuk.corkCharge.domain.corkageStore.domain.CorkageStore;
 import konkuk.corkCharge.domain.corkageStore.domain.MultiCorkage;
-import konkuk.corkCharge.domain.image.repository.ImageRepository;
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
 import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
 import konkuk.corkCharge.domain.restaurant.dto.mapper.*;
@@ -13,6 +15,7 @@ import konkuk.corkCharge.domain.restaurant.dto.request.UserLocationRequest;
 import konkuk.corkCharge.domain.restaurant.dto.response.*;
 import konkuk.corkCharge.domain.restaurant.repository.RestaurantDistanceProjection;
 import konkuk.corkCharge.domain.restaurant.repository.RestaurantRepository;
+import konkuk.corkCharge.domain.user.repository.UserRepository;
 import konkuk.corkCharge.global.api.naverMapsApi.NaverGeocodingClient;
 import konkuk.corkCharge.global.api.naverMapsApi.dto.Address;
 import konkuk.corkCharge.global.api.naverMapsApi.dto.NaverMapsResponse;
@@ -22,10 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.*;
@@ -67,8 +67,9 @@ public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
     private final NaverGeocodingClient naverGeocodingClient;
-    private final ImageRepository imageRepository;
     private final CorkageStoreRepository corkageStoreRepository;
+    private final RestaurantBookmarkGroupItemRepository groupItemRepository;
+    private final UserRepository userRepository;
 
     private final ClusterListResponseMapper clusterListResponseMapper;
     private final RestaurantDetailResponseMapper restaurantDetailResponseMapper;
@@ -111,15 +112,6 @@ public class RestaurantService {
                 .map(GetSearchRestaurantResponse::from)
                 .toList();
     }
-
-//    @Transactional
-//    public List<GetHotRestaurantResponse> getHotRestaurants() {
-//        List<Restaurant> hotRestaurants = restaurantRepository.findByHasCorkageFalseAndBookmarkCountGreaterThanEqual(5);
-//
-//        return hotRestaurants.stream()
-//                .map(hotRestaurantResponseMapper::toResponse)
-//                .toList();
-//    }
 
     @Transactional
     public List<?> filterRestaurants(GetFilterRequest request) {
@@ -253,28 +245,6 @@ public class RestaurantService {
         };
     }
 
-//    @Transactional(readOnly = true)
-//    public GetHomeRestaurantResponse getHomeRestaurant() {
-//        Restaurant r = restaurantRepository
-//                .findFirstByHasCorkageFalseOrderByBookmarkCountDesc()
-//                .orElseThrow(() -> new CustomException(RESTAURANT_NOT_FOUND));
-//
-//        // 1순위: 레스토랑 MAIN 이미지
-//        String imageUrl = imageRepository
-//                .findFirstByCategoryAndTypeIdAndType(RESTAURANT, r.getRestaurantId(), MAIN)
-//                // 2순위(없으면): 아무 레스토랑 이미지 한 장
-//                .or(() -> imageRepository.findFirstByCategoryAndTypeIdOrderByCreatedAtAsc(RESTAURANT, r.getRestaurantId()))
-//                .map(Image::getImageUrl)
-//                .orElse(null);
-//
-//        return new GetHomeRestaurantResponse(
-//                r.getRestaurantId(),
-//                r.getName(),
-//                r.getBookmarkCount() == null ? 0 : r.getBookmarkCount(),
-//                imageUrl
-//        );
-//    }
-
     @Transactional(readOnly = true)
     public List<GetHomeRestaurantResponse> getNewRestaurants(UserLocationRequest req) {
         LocalDateTime from = LocalDateTime.now().minusDays(NEW_RESTAURANT_DAYS);
@@ -402,11 +372,6 @@ public class RestaurantService {
                     restaurantRepository.findNearbyRestaurantIdsWithinRadiusLimit(
                             req.lat(), req.lon(), RADIUS_METERS_NEAR_BY, LIMIT
                     );
-
-//            nearbyCard = nearbyIds.stream()
-//                    .map(restaurantSummaryService::getSummary)
-//                    .map(homeRestaurantCardMapper::toCard)
-//                    .toList();
         }
 
         // 추천 매장 top5
@@ -422,11 +387,6 @@ public class RestaurantService {
                         LIMIT
                 );
 
-//        List<HomeRestaurantCard> recommendCard = recommendIds.stream()
-//                .map(restaurantSummaryService::getSummary)
-//                .map(homeRestaurantCardMapper::toCard)
-//                .toList();
-
         List<HomeRestaurantCard> nearbyCard = restaurantSummaryService.getSummariesInOrder(nearbyIds).stream()
                 .map(homeRestaurantCardMapper::toCard)
                 .toList();
@@ -436,6 +396,70 @@ public class RestaurantService {
                 .toList();
 
         return new GetRestaurantTabResponse(nearbyCard, recommendCard);
+    }
+
+    @Transactional(readOnly = true)
+    public GetGroupRestaurantPinsResponse getGroupRestaurantPins(Long userId, double latMin, double latMax, double lonMin, double lonMax) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String wkt = toEnvelopeWkt(lonMin, latMin, lonMax, latMax);
+
+        List<GroupRestaurantPinProjection> rows = groupItemRepository.findGroupRestaurantPinsInBounds(userId, wkt);
+
+        // 그룹Id 기준으로 map에 넣음
+        Map<Long, GroupAccumulator> map = new LinkedHashMap<>();
+
+        for (GroupRestaurantPinProjection row : rows) {
+            GroupAccumulator acc = map.computeIfAbsent(
+                    row.getGroupId(),
+                    key -> new GroupAccumulator(
+                            row.getGroupId(),
+                            row.getName(),
+                            row.getColor(),
+                            row.getVisibility()
+                    )
+            );
+
+            // 각 그룹에 핀 추가
+            acc.pins.add(new GetGroupRestaurantPinsResponse.Pin(
+                    row.getRestaurantId(),
+                    row.getLatitude(),
+                    row.getLongitude()
+            ));
+
+            acc.restaurantIds.add(row.getRestaurantId());
+        }
+
+        List<GetGroupRestaurantPinsResponse.GroupPins> groups = map.values().stream()
+                .map(acc -> new GetGroupRestaurantPinsResponse.GroupPins(
+                        acc.groupId,
+                        acc.name,
+                        acc.color,
+                        acc.visibility,
+                        acc.restaurantIds.size(),
+                        acc.pins
+                ))
+                .toList();
+
+        return new GetGroupRestaurantPinsResponse(groups.size(), groups);
+    }
+
+    private static class GroupAccumulator {
+        final Long groupId;
+        final String name;
+        final String color;
+        final BookmarkGroupVisibility visibility;
+
+        final List<GetGroupRestaurantPinsResponse.Pin> pins = new ArrayList<>();
+        final Set<Long> restaurantIds = (Set<Long>) new HashSet<Long>();
+
+        GroupAccumulator(Long groupId, String name, String color, BookmarkGroupVisibility visibility) {
+            this.groupId = groupId;
+            this.name = name;
+            this.color = color;
+            this.visibility = visibility;
+        }
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -452,7 +452,7 @@ public class RestaurantService {
         final BookmarkGroupVisibility visibility;
 
         final List<GetGroupRestaurantPinsResponse.Pin> pins = new ArrayList<>();
-        final Set<Long> restaurantIds = (Set<Long>) new HashSet<Long>();
+        final Set<Long> restaurantIds = new HashSet<>();
 
         GroupAccumulator(Long groupId, String name, String color, BookmarkGroupVisibility visibility) {
             this.groupId = groupId;

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantSummaryService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantSummaryService.java
@@ -261,7 +261,7 @@ public class RestaurantSummaryService {
     /**
      * 쓰기 작업 후 Summary 캐시 제거용
      */
-    @CacheEvict(cacheNames = "restaurantSummary", key = "#restaurantId")
+    @CacheEvict(cacheNames = "restaurantSummary", key = "#p0")
     public void evictSummary(Long restaurantId) {
         // 캐시만 날리면 되므로 바디 없음
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#123 

## 📝작업 내용
- 사용자가 저장한 매장을 그룹 단위로 묶어 지도 핀 정보로 응답하도록 했습니다.
- 공간 인덱스(ST_Within) 기반 쿼리를 사용하여 현재 지도 영역 안에 있는 매장 핀만 조회하도록 구현했습니다.

<img width="1108" height="740" alt="스크린샷 2026-01-11 오후 5 30 15" src="https://github.com/user-attachments/assets/c828ef4a-e067-47b4-bec1-46ec0e5f37e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지도 보기에서 북마크 그룹별 식당 핀을 조회·표시하는 기능 추가
  * 지정된 지리적 범위 내 그룹화된 식당 핀을 반환하는 API 엔드포인트 추가
  * 그룹별 요약(그룹 수, 그룹별 핀 목록 포함) 응답 형식 추가

* **개선 사항**
  * 그룹 기반 핀 조회 성능 및 응답 구조 정리
  * 캐시 키 처리 방식 개선으로 캐시 동작 안정성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->