### PR TITLE
[FEAT] 매장/리뷰 리스트에 scrap 필드 추가

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/bookmark/controller/BookmarkGroupController.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/controller/BookmarkGroupController.java
@@ -62,8 +62,8 @@ public class BookmarkGroupController {
     @GetMapping("/{groupId}")
     public BaseResponse<GetBookmarkGroupDetailResponse> getGroupDetail(
             @LoginUserId Long userId,
-            @PathVariable Long groupId,
-            @RequestParam(required = false, defaultValue = "LATEST")
+            @PathVariable(name = "groupId") Long groupId,
+            @RequestParam(required = false, defaultValue = "LATEST", name = "sort")
             BookmarkGroupSort sort
     ) {
         return BaseResponse.ok(

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/repository/BookmarkRepository.java
@@ -3,6 +3,8 @@ package konkuk.corkCharge.domain.bookmark.repository;
 import konkuk.corkCharge.domain.bookmark.domain.Bookmark;
 import konkuk.corkCharge.domain.bookmark.domain.BookmarkTargetType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,6 +20,19 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
             Long userId,
             BookmarkTargetType targetType,
             Long targetId
+    );
+
+    @Query("""
+        select b
+          from Bookmark b
+         where b.user.userId = :userId
+           and b.targetType = :targetType
+           and b.targetId in :targetIds
+    """)
+    List<Bookmark> findAllByUserIdAndTargetTypeAndTargetIdIn(
+            @Param("userId") Long userId,
+            @Param("targetType") BookmarkTargetType targetType,
+            @Param("targetIds") List<Long> targetIds
     );
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -86,7 +86,6 @@ public class RestaurantController {
             @LoginUserId(required = false) Long userId,
             @RequestBody UserLocationRequest request
     ) {
-        System.out.println("호출됨");
         return BaseResponse.ok(restaurantService.getNearByRestaurants(userId, request));
     }
 

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/controller/RestaurantController.java
@@ -59,35 +59,42 @@ public class RestaurantController {
 
     @PostMapping("/cluster/list")
     public BaseResponse<GetClusterListResponse> getClusterRestaurantList(
+            @LoginUserId(required = false) Long userId,
             @RequestBody GetClusterListRequest request
     ) {
-        return BaseResponse.ok(restaurantService.getClusterList(request));
+        return BaseResponse.ok(restaurantService.getClusterList(userId, request));
     }
 
     @PostMapping("/new")
     public BaseResponse<List<GetHomeRestaurantResponse>> getNewRestaurant(
+            @LoginUserId(required = false) Long userId,
             @RequestBody UserLocationRequest request
-            ) {
-        return BaseResponse.ok(restaurantService.getNewRestaurants(request));
+    ) {
+        return BaseResponse.ok(restaurantService.getNewRestaurants(userId, request));
     }
 
     @PostMapping("/category")
     public BaseResponse<List<GetHomeRestaurantResponse>> getCategoryRestaurants(
+            @LoginUserId(required = false) Long userId,
             @RequestBody GetCategoryRestaurantRequest request
-            ) {
-        return BaseResponse.ok(restaurantService.getCategoryRestaurants(request));
+    ) {
+        return BaseResponse.ok(restaurantService.getCategoryRestaurants(userId, request));
     }
 
     @PostMapping("/nearby")
     public BaseResponse<List<GetHomeRestaurantResponse>> getNearbyRestaurants(
+            @LoginUserId(required = false) Long userId,
             @RequestBody UserLocationRequest request
     ) {
-        return BaseResponse.ok(restaurantService.getNearByRestaurants(request));
+        System.out.println("호출됨");
+        return BaseResponse.ok(restaurantService.getNearByRestaurants(userId, request));
     }
 
     @GetMapping("/recommand")
-    public BaseResponse<List<GetHomeRestaurantResponse>> getRecommandRestaurants() {
-        return BaseResponse.ok(restaurantService.getRecommendRestaurants());
+    public BaseResponse<List<GetHomeRestaurantResponse>> getRecommandRestaurants(
+            @LoginUserId(required = false) Long userId
+    ) {
+        return BaseResponse.ok(restaurantService.getRecommendRestaurants(userId));
     }
 
     @PostMapping("/home")

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/ClusterListResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/ClusterListResponseMapper.java
@@ -19,7 +19,8 @@ public class ClusterListResponseMapper {
     public GetClusterListResponse.Item toItem(
             Restaurant restaurant,
             CorkageStore corkageStore,
-            String[] imageUrls
+            String[] imageUrls,
+            boolean scrap
     ) {
         String corkagePrice = formatCorkagePrice(corkageStore);
         List<String> corkageOptions = decodeOptions(corkageStore.getOptionBits(), corkageStore.getEtcContent());
@@ -32,7 +33,8 @@ public class ClusterListResponseMapper {
                 restaurant.getOpeningHours(),
                 corkagePrice,
                 corkageOptions,
-                imageUrls == null ? new String[0] : imageUrls
+                imageUrls == null ? new String[0] : imageUrls,
+                scrap
         );
     }
 

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/HomeRestaurantResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/HomeRestaurantResponseMapper.java
@@ -15,7 +15,8 @@ public class HomeRestaurantResponseMapper {
 
     public GetHomeRestaurantResponse toResponse(
             RestaurantSummary summary,
-            Double distanceKm
+            Double distanceKm,
+            boolean scrap
     ) {
         List<String> corkageOptions = decodeOptions(summary.getOptionBits(), summary.getOptionEtcContent());
 
@@ -29,7 +30,8 @@ public class HomeRestaurantResponseMapper {
                 corkageOptions,
                 distanceKm,
                 summary.getMainImageUrl(),
-                summary.getOpeningHours()
+                summary.getOpeningHours(),
+                scrap
         );
     }
 

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetClusterListResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetClusterListResponse.java
@@ -14,6 +14,7 @@ public record GetClusterListResponse(
             String openingHours,
             String corkagePrice,
             List<String> corkageOptions,
-            String[] imageUrls
+            String[] imageUrls,
+            boolean scrap
     ) {}
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetHomeRestaurantResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetHomeRestaurantResponse.java
@@ -12,6 +12,7 @@ public record GetHomeRestaurantResponse(
         List<String> corkageOptions,
         Double distance,          // km기준, lat/lon 없으면 null
         String mainImageUrls,
-        String openingHours
+        String openingHours,
+        boolean scrap
 ) {
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/repository/RestaurantRepository.java
@@ -44,26 +44,38 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
         """)
     List<Restaurant> findRestaurantsWithoutValidCoordinates();
 
-    // lat/lon 없을 때(그냥 2주 이내 최신순 전체)
-    List<Restaurant> findByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(LocalDateTime from);
+    // lat/lon 없을 때(그냥 2주 이내 최신순 콜키지 매장)
+    @Query("""
+        select r
+          from CorkageStore cs
+          join cs.restaurant r
+         where cs.createdAt >= :from
+           and r.hasCorkage = true
+         order by cs.createdAt desc, r.restaurantId desc
+    """)
+    List<Restaurant> findNewCorkageRestaurantsByCorkageCreatedAt(
+            @Param("from") LocalDateTime from
+    );
 
     // lat/lon 있을 때: DB에서 distance(km) 계산해서 함께 반환
     @Query(value = """
-        SELECT
-            r.restaurant_id AS restaurantId,
-            ROUND(
-                ST_Distance_Sphere(
-                    r.location,
-                    ST_SRID(POINT(:lon, :lat), 4326)
-                ) / 1000,
-                1
-            ) AS distanceKm
-        FROM restaurant r
-        WHERE r.created_at >= :from
-          AND r.has_corkage = 1
-          AND ST_X(r.location) != 0 AND ST_Y(r.location) != 0
-        ORDER BY r.created_at DESC
-        """, nativeQuery = true)
+    SELECT
+        r.restaurant_id AS restaurantId,
+        ROUND(
+            ST_Distance_Sphere(
+                r.location,
+                ST_SRID(POINT(:lon, :lat), 4326)
+            ) / 1000,
+            1
+        ) AS distanceKm
+    FROM restaurant r
+      JOIN corkage_store cs
+        ON cs.restaurant_id = r.restaurant_id
+    WHERE cs.created_at >= :from
+      AND r.has_corkage = 1
+      AND ST_X(r.location) != 0 AND ST_Y(r.location) != 0
+    ORDER BY cs.created_at DESC, r.restaurant_id DESC
+    """, nativeQuery = true)
     List<RestaurantDistanceProjection> findNewRestaurantsWithDistance(
             @Param("from") LocalDateTime from,
             @Param("lat") double lat,

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantService.java
@@ -1,6 +1,9 @@
 package konkuk.corkCharge.domain.restaurant.service;
 
+import konkuk.corkCharge.domain.bookmark.domain.Bookmark;
 import konkuk.corkCharge.domain.bookmark.domain.BookmarkGroupVisibility;
+import konkuk.corkCharge.domain.bookmark.domain.BookmarkTargetType;
+import konkuk.corkCharge.domain.bookmark.repository.BookmarkRepository;
 import konkuk.corkCharge.domain.bookmark.repository.GroupRestaurantPinProjection;
 import konkuk.corkCharge.domain.bookmark.repository.RestaurantBookmarkGroupItemRepository;
 import konkuk.corkCharge.domain.corkageStore.repository.CorkageStoreRepository;
@@ -29,6 +32,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static konkuk.corkCharge.domain.bookmark.domain.BookmarkTargetType.RESTAURANT;
 import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.*;
 
 @Service
@@ -82,6 +86,7 @@ public class RestaurantService {
 
     private final RestaurantSummaryService restaurantSummaryService;
     private final HomeRestaurantResponseMapper homeRestaurantResponseMapper;
+    private final BookmarkRepository bookmarkRepository;
 
     @Transactional(readOnly = true)
     public List<GetRestaurantListResponse> getCorkageRestaurants() {
@@ -216,7 +221,7 @@ public class RestaurantService {
     }
 
     @Transactional(readOnly = true)
-    public GetClusterListResponse getClusterList(GetClusterListRequest req) {
+    public GetClusterListResponse getClusterList(Long userId, GetClusterListRequest req) {
 
         if (req.restaurantIds() == null || req.restaurantIds().isEmpty()) {
             return new GetClusterListResponse(0, List.of());
@@ -235,8 +240,7 @@ public class RestaurantService {
                         (a, b) -> a
                 ));
 
-        Map<Long, String[]> imageMap = imageRepository
-                .findRestaurantMainImagesByRestaurantIds(req.restaurantIds())
+        Map<Long, String[]> imageMap = imageRepository.findRestaurantMainImagesByRestaurantIds(req.restaurantIds())
                 .stream()
                 .collect(Collectors.groupingBy(
                         Image::getTypeId,
@@ -249,6 +253,9 @@ public class RestaurantService {
                         Map.Entry::getKey,
                         e -> e.getValue().toArray(new String[0])
                 ));
+
+        // scrap 로직
+        Set<Long> scrappedRestaurantIds = getScrappedRestaurantIds(userId, req.restaurantIds());
 
         // 정렬 방법
         Comparator<Restaurant> comparator = switch (sort) {
@@ -274,11 +281,13 @@ public class RestaurantService {
                     if (cs == null || cs.getCorkageType() == null) {
                         throw new CustomException(BAD_REQUEST);
                     }
+                    boolean scrap = (userId != null) && scrappedRestaurantIds.contains(r.getRestaurantId());
 
                     return clusterListResponseMapper.toItem(
                             r,
                             cs,
-                            imageMap.getOrDefault(r.getRestaurantId(), new String[0])
+                            imageMap.getOrDefault(r.getRestaurantId(), new String[0]),
+                            scrap
                     );
                 })
                 .toList();
@@ -305,7 +314,7 @@ public class RestaurantService {
     }
 
     @Transactional(readOnly = true)
-    public List<GetHomeRestaurantResponse> getNewRestaurants(UserLocationRequest req) {
+    public List<GetHomeRestaurantResponse> getNewRestaurants(Long userId, UserLocationRequest req) {
         LocalDateTime from = LocalDateTime.now().minusDays(NEW_RESTAURANT_DAYS);
 
         // 사용자 좌표가 있는 경우
@@ -319,31 +328,48 @@ public class RestaurantService {
                             RestaurantDistanceProjection::getDistanceKm
                     ));
 
+            List<Long> restaurantIds = rows.stream()
+                    .map(RestaurantDistanceProjection::getRestaurantId)
+                    .toList();
+
+            Set<Long> scrappedRestaurantIds = getScrappedRestaurantIds(userId, restaurantIds);
+
             return rows.stream()
                     .map(row -> {
                         Long id = row.getRestaurantId();
                         RestaurantSummary summary = restaurantSummaryService.getSummary(id);
 
-                        return homeRestaurantResponseMapper.toResponse(summary, distanceMap.get(id));
+                        boolean scrap = (userId != null) && scrappedRestaurantIds.contains(id);
+
+                        return homeRestaurantResponseMapper.toResponse(summary, distanceMap.get(id), scrap);
                     })
                     .toList();
         }
 
         // 사용자 좌표가 없는 경우
-        List<Restaurant> restaurants = restaurantRepository.findByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(from);
+        List<Restaurant> rows = restaurantRepository.findNewCorkageRestaurantsByCorkageCreatedAt(from);
 
-        return restaurants.stream()
+        List<Long> restaurantIds = rows.stream()
+                .map(Restaurant::getRestaurantId)
+                .toList();
+
+        Set<Long> scrappedRestaurantIds = getScrappedRestaurantIds(userId, restaurantIds);
+
+        return rows.stream()
                 .map(r -> {
                     Long id = r.getRestaurantId();
                     RestaurantSummary summary = restaurantSummaryService.getSummary(id);
 
-                    return homeRestaurantResponseMapper.toResponse(summary, null);
+                    boolean scrap = (userId != null) && scrappedRestaurantIds.contains(id);
+
+                    return homeRestaurantResponseMapper.toResponse(summary, null, scrap);
                 })
                 .toList();
     }
 
+
     @Transactional(readOnly = true)
-    public List<GetHomeRestaurantResponse> getCategoryRestaurants(GetCategoryRestaurantRequest req) {
+    public List<GetHomeRestaurantResponse> getCategoryRestaurants(Long userId, GetCategoryRestaurantRequest req) {
         if (!ALLOWED_CATEGORIES.contains(req.category())) {
             throw new CustomException(CATEGORY_NOT_FOUND);
         }
@@ -356,30 +382,49 @@ public class RestaurantService {
                             req.lon()
                     );
 
+            List<Long> restaurantIds = rows.stream()
+                    .map(RestaurantDistanceProjection::getRestaurantId)
+                    .toList();
+
+            Set<Long> scrappedRestaurantIds = getScrappedRestaurantIds(userId, restaurantIds);
+
             return rows.stream()
                     .map(row -> {
                         Long id = row.getRestaurantId();
                         RestaurantSummary summary = restaurantSummaryService.getSummary(id);
-                        return homeRestaurantResponseMapper.toResponse(summary, row.getDistanceKm());
+
+                        boolean scrap = userId != null && scrappedRestaurantIds.contains(id);
+
+                        return homeRestaurantResponseMapper.toResponse(summary, row.getDistanceKm(), scrap);
                     })
                     .toList();
         }
 
         // 좌표 없는 경우
-        List<Restaurant> restaurants =
+        List<Restaurant> rows =
                 restaurantRepository.findByHasCorkageTrueAndRawCategoryContainingOrderByBookmarkCountDesc(req.category());
 
-        return restaurants.stream()
+        List<Long> restaurantsIds = rows.stream()
+                .map(Restaurant::getRestaurantId)
+                .toList();
+
+        Set<Long> scrappedRestaurantIds = getScrappedRestaurantIds(userId, restaurantsIds);
+
+        return rows.stream()
                 .map(r -> {
                     Long id = r.getRestaurantId();
                     RestaurantSummary summary = restaurantSummaryService.getSummary(id);
-                    return homeRestaurantResponseMapper.toResponse(summary, null);
+
+                    boolean scrap = userId != null && scrappedRestaurantIds.contains(id);
+
+                    return homeRestaurantResponseMapper.toResponse(summary, null, scrap);
                 })
                 .toList();
     }
 
+
     @Transactional(readOnly = true)
-    public List<GetHomeRestaurantResponse> getNearByRestaurants(UserLocationRequest req) {
+    public List<GetHomeRestaurantResponse> getNearByRestaurants(Long userId, UserLocationRequest req) {
         if (req == null || !req.hasUserLocation()) {
             throw new CustomException(LOCATION_REQUIRED);
         }
@@ -387,17 +432,26 @@ public class RestaurantService {
         List<RestaurantDistanceProjection> rows =
                 restaurantRepository.findNearbyRestaurantsWithinRadius(req.lat(), req.lon(), RADIUS_METERS_NEAR_BY);
 
+        List<Long> restaurantIds = rows.stream()
+                .map(RestaurantDistanceProjection::getRestaurantId)
+                .toList();
+
+        Set<Long> scrappedRestaurantIds = getScrappedRestaurantIds(userId, restaurantIds);
+
         return rows.stream()
                 .map(row -> {
                     Long id = row.getRestaurantId();
                     RestaurantSummary summary = restaurantSummaryService.getSummary(id);
-                    return homeRestaurantResponseMapper.toResponse(summary, row.getDistanceKm());
+
+                    boolean scrap = userId != null && scrappedRestaurantIds.contains(id);
+
+                    return homeRestaurantResponseMapper.toResponse(summary, row.getDistanceKm(), scrap);
                 })
                 .toList();
     }
 
     @Transactional(readOnly = true)
-    public List<GetHomeRestaurantResponse> getRecommendRestaurants() {
+    public List<GetHomeRestaurantResponse> getRecommendRestaurants(Long userId) {
         List<RestaurantDistanceProjection> rows =
                 restaurantRepository.findRecommendRestaurantsWithinRadius(
                         RADIUS_METERS_RECOMMEND,
@@ -409,13 +463,30 @@ public class RestaurantService {
                         YONGSAN_LAT, YONGSAN_LON
                 );
 
+        List<Long> restaurantIds = rows.stream()
+                .map(RestaurantDistanceProjection::getRestaurantId)
+                .toList();
+
+        Set<Long> scrappedRestaurantIds = getScrappedRestaurantIds(userId, restaurantIds);
+
         return rows.stream()
                 .map(row -> {
                     Long id = row.getRestaurantId();
                     RestaurantSummary summary = restaurantSummaryService.getSummary(id);
-                    return homeRestaurantResponseMapper.toResponse(summary, row.getDistanceKm());
+
+                    boolean scrap = scrappedRestaurantIds.contains(id);
+
+                    return homeRestaurantResponseMapper.toResponse(summary, row.getDistanceKm(), scrap);
                 })
                 .toList();
+    }
+
+    private Set<Long> getScrappedRestaurantIds(Long userId, List<Long> restaurantIds) {
+        Set<Long> scrappedRestaurantIds = (userId == null) ? Collections.emptySet() : bookmarkRepository
+                .findAllByUserIdAndTargetTypeAndTargetIdIn(userId, RESTAURANT, restaurantIds).stream()
+                .map(Bookmark::getTargetId)
+                .collect(Collectors.toSet());
+        return scrappedRestaurantIds;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/konkuk/corkCharge/domain/review/controller/ReviewController.java
+++ b/src/main/java/konkuk/corkCharge/domain/review/controller/ReviewController.java
@@ -4,6 +4,7 @@ import konkuk.corkCharge.domain.review.dto.request.CorkageReviewSort;
 import konkuk.corkCharge.domain.review.dto.request.PatchUpdateReviewRequest;
 import konkuk.corkCharge.domain.review.dto.request.PostReviewCreateRequest;
 import konkuk.corkCharge.domain.review.dto.response.GetCorkageReviewResponse;
+import konkuk.corkCharge.domain.review.dto.response.GetHomeCorkageReviewResponse;
 import konkuk.corkCharge.domain.review.dto.response.GetRestaurantReviewResponse;
 import konkuk.corkCharge.domain.review.service.ReviewService;
 import konkuk.corkCharge.global.annotation.LoginUserId;
@@ -34,9 +35,10 @@ public class ReviewController {
 
     @GetMapping("/corkageReview")
     public BaseResponse<List<GetCorkageReviewResponse>> getCorkageReview(
+            @LoginUserId(required = false) Long userId,
             @RequestParam(name = "sort", defaultValue = "BOOKMARK") CorkageReviewSort sort
     ) {
-        return BaseResponse.ok(reviewService.getCorkageReviews(sort));
+        return BaseResponse.ok(reviewService.getCorkageReviews(userId, sort));
     }
 
     @PatchMapping("/{reviewId}")
@@ -61,13 +63,14 @@ public class ReviewController {
 
     @GetMapping("/{restaurantId}")
     public BaseResponse<List<GetRestaurantReviewResponse>> getRestaurantReviews(
+            @LoginUserId(required = false) Long userId,
             @PathVariable(name = "restaurantId") Long restaurantId
     ) {
-        return BaseResponse.ok(reviewService.getRestaurantReviews(restaurantId));
+        return BaseResponse.ok(reviewService.getRestaurantReviews(userId, restaurantId));
     }
 
     @GetMapping("/home")
-    public BaseResponse<List<GetCorkageReviewResponse>> getHomeCorkageReviews() {
+    public BaseResponse<List<GetHomeCorkageReviewResponse>> getHomeCorkageReviews() {
         return BaseResponse.ok(reviewService.getHomeCorkageReviews());
     }
 

--- a/src/main/java/konkuk/corkCharge/domain/review/dto/mapper/GetRestaurantReviewResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/review/dto/mapper/GetRestaurantReviewResponseMapper.java
@@ -11,7 +11,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class GetRestaurantReviewResponseMapper {
 
-    public GetRestaurantReviewResponse toResponse(Review review, List<String> imageUrls) {
+    public GetRestaurantReviewResponse toResponse(Review review, List<String> imageUrls, boolean scrap) {
         return new GetRestaurantReviewResponse(
                 review.getReviewId(),
                 review.getUser().getName(),
@@ -19,7 +19,8 @@ public class GetRestaurantReviewResponseMapper {
                 review.getRating(),
                 review.getCreatedAt(),
                 imageUrls,
-                review.getBookmarkCount() == null ? 0 : review.getBookmarkCount()
+                review.getBookmarkCount() == null ? 0 : review.getBookmarkCount(),
+                scrap
         );
     }
 }

--- a/src/main/java/konkuk/corkCharge/domain/review/dto/response/GetCorkageReviewResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/review/dto/response/GetCorkageReviewResponse.java
@@ -12,6 +12,7 @@ public record GetCorkageReviewResponse(
         int rating,
         LocalDateTime createdAt,
         List<String> imageUrls,
-        int bookmarkCount
+        int bookmarkCount,
+        boolean scrap
 ) {
 }

--- a/src/main/java/konkuk/corkCharge/domain/review/dto/response/GetHomeCorkageReviewResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/review/dto/response/GetHomeCorkageReviewResponse.java
@@ -3,14 +3,13 @@ package konkuk.corkCharge.domain.review.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record GetRestaurantReviewResponse(
+public record GetHomeCorkageReviewResponse(
         Long reviewId,
+        Long restaurantId,
+        String restaurantName,
         String writer,
         String content,
         int rating,
         LocalDateTime createdAt,
-        List<String> imageUrls,
-        int bookmarkCount,
-        boolean scrap
-) {
-}
+        List<String> imageUrls
+) { }

--- a/src/main/java/konkuk/corkCharge/domain/review/service/ReviewService.java
+++ b/src/main/java/konkuk/corkCharge/domain/review/service/ReviewService.java
@@ -1,5 +1,8 @@
 package konkuk.corkCharge.domain.review.service;
 
+import konkuk.corkCharge.domain.bookmark.domain.Bookmark;
+import konkuk.corkCharge.domain.bookmark.domain.BookmarkTargetType;
+import konkuk.corkCharge.domain.bookmark.repository.BookmarkRepository;
 import konkuk.corkCharge.domain.image.domain.Image;
 import konkuk.corkCharge.domain.image.repository.ImageRepository;
 import konkuk.corkCharge.domain.image.service.S3ImageService;
@@ -12,6 +15,7 @@ import konkuk.corkCharge.domain.review.dto.request.CorkageReviewSort;
 import konkuk.corkCharge.domain.review.dto.request.PatchUpdateReviewRequest;
 import konkuk.corkCharge.domain.review.dto.request.PostReviewCreateRequest;
 import konkuk.corkCharge.domain.review.dto.response.GetCorkageReviewResponse;
+import konkuk.corkCharge.domain.review.dto.response.GetHomeCorkageReviewResponse;
 import konkuk.corkCharge.domain.review.dto.response.GetRestaurantReviewResponse;
 import konkuk.corkCharge.domain.review.repository.CorkageReviewProjection;
 import konkuk.corkCharge.domain.review.repository.ReviewRepository;
@@ -23,8 +27,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static konkuk.corkCharge.domain.image.domain.ImageCategory.REVIEW;
@@ -42,6 +48,7 @@ public class ReviewService {
     private final RestaurantSummaryService restaurantSummaryService;
 
     private final GetRestaurantReviewResponseMapper getRestaurantReviewResponseMapper;
+    private final BookmarkRepository bookmarkRepository;
 
     @Transactional
     public void createReview(Long userId, Long restaurantId,
@@ -95,7 +102,7 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
-    public List<GetCorkageReviewResponse> getCorkageReviews(CorkageReviewSort sort) {
+    public List<GetCorkageReviewResponse> getCorkageReviews(Long userId, CorkageReviewSort sort) {
 
         List<CorkageReviewProjection> rows = switch (sort) {
             case LATEST -> reviewRepository.findAllCorkageReviewsOrderByLatest();
@@ -116,18 +123,25 @@ public class ReviewService {
                                 Collectors.mapping(Image::getImageUrl, Collectors.toList())
                         ));
 
+        Set<Long> scrappedReviewIds = getScrappedReviewIds(userId, reviewIds);
+
         return rows.stream()
-                .map(row -> new GetCorkageReviewResponse(
-                        row.getReviewId(),
-                        row.getRestaurantId(),
-                        row.getRestaurantName(),
-                        row.getWriter(),
-                        row.getContent(),
-                        row.getRating() == null ? 0 : row.getRating(),
-                        row.getCreatedAt(),
-                        imageMap.getOrDefault(row.getReviewId(), List.of()),
-                        row.getBookmarkCount() == null ? 0 : row.getBookmarkCount()
-                ))
+                .map(row -> {
+                    boolean scrap = userId != null && scrappedReviewIds.contains(row.getReviewId());
+
+                    return new GetCorkageReviewResponse(
+                            row.getReviewId(),
+                            row.getRestaurantId(),
+                            row.getRestaurantName(),
+                            row.getWriter(),
+                            row.getContent(),
+                            row.getRating() == null ? 0 : row.getRating(),
+                            row.getCreatedAt(),
+                            imageMap.getOrDefault(row.getReviewId(), List.of()),
+                            row.getBookmarkCount() == null ? 0 : row.getBookmarkCount(),
+                            scrap
+                    );
+                })
                 .toList();
     }
 
@@ -192,7 +206,7 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
-    public List<GetRestaurantReviewResponse> getRestaurantReviews(Long restaurantId) {
+    public List<GetRestaurantReviewResponse> getRestaurantReviews(Long userId, Long restaurantId) {
 
         List<Review> reviews =
                 reviewRepository.findByRestaurant_RestaurantIdOrderByCreatedAtDesc(restaurantId);
@@ -214,16 +228,31 @@ public class ReviewService {
                                 Collectors.mapping(Image::getImageUrl, Collectors.toList())
                         ));
 
+        Set<Long> scrappedReviewIds = getScrappedReviewIds(userId, reviewIds);
+
         return reviews.stream()
-                .map(review -> getRestaurantReviewResponseMapper.toResponse(
-                        review,
-                        imageMap.getOrDefault(review.getReviewId(), List.of())
-                ))
+                .map(review -> {
+                    boolean scrap =  userId != null && scrappedReviewIds.contains(review.getReviewId());
+
+                    return getRestaurantReviewResponseMapper.toResponse(
+                            review,
+                            imageMap.getOrDefault(review.getReviewId(), List.of()),
+                            scrap
+                            );
+                })
                 .toList();
     }
 
+    private Set<Long> getScrappedReviewIds(Long userId, List<Long> reviewIds) {
+        Set<Long> scrappedReviewIds = (userId == null) ? Collections.emptySet() : bookmarkRepository
+                .findAllByUserIdAndTargetTypeAndTargetIdIn(userId, BookmarkTargetType.REVIEW, reviewIds).stream()
+                .map(Bookmark::getTargetId)
+                .collect(Collectors.toSet());
+        return scrappedReviewIds;
+    }
+
     @Transactional(readOnly = true)
-    public List<GetCorkageReviewResponse> getHomeCorkageReviews() {
+    public List<GetHomeCorkageReviewResponse> getHomeCorkageReviews() {
         final int LIMIT = 5;
 
         List<CorkageReviewProjection> rows =
@@ -244,7 +273,7 @@ public class ReviewService {
                         ));
 
         return rows.stream()
-                .map(row -> new GetCorkageReviewResponse(
+                .map(row -> new GetHomeCorkageReviewResponse(
                         row.getReviewId(),
                         row.getRestaurantId(),
                         row.getRestaurantName(),
@@ -252,8 +281,7 @@ public class ReviewService {
                         row.getContent(),
                         row.getRating() == null ? 0 : row.getRating(),
                         row.getCreatedAt(),
-                        imageMap.getOrDefault(row.getReviewId(), List.of()),
-                        row.getBookmarkCount() == null ? 0 : row.getBookmarkCount()
+                        imageMap.getOrDefault(row.getReviewId(), List.of())
                 ))
                 .toList();
     }

--- a/src/main/java/konkuk/corkCharge/global/annotation/LoginUserId.java
+++ b/src/main/java/konkuk/corkCharge/global/annotation/LoginUserId.java
@@ -5,4 +5,6 @@ import java.lang.annotation.*;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface LoginUserId {}
+public @interface LoginUserId {
+    boolean required() default true;
+}

--- a/src/main/java/konkuk/corkCharge/global/oauth/jwt/LoginArgumentResolver.java
+++ b/src/main/java/konkuk/corkCharge/global/oauth/jwt/LoginArgumentResolver.java
@@ -2,7 +2,9 @@ package konkuk.corkCharge.global.oauth.jwt;
 
 import konkuk.corkCharge.global.annotation.LoginUserId;
 import konkuk.corkCharge.global.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.*;
 
+@Slf4j
 @Component
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -28,9 +31,14 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
 
+        LoginUserId anno = parameter.getParameterAnnotation(LoginUserId.class);
+        boolean required = anno.required();
+
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
-        if (auth == null || !auth.isAuthenticated()) {
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            if (!required)
+                return null;
             throw new CustomException(AUTH_REQUIRED);
         }
         if (!(auth instanceof JwtTokenAuthentication jwtAuth)) {


### PR DESCRIPTION
## #️⃣연관된 이슈

#125

## 📝작업 내용
- 유저가 저장한 매장/리뷰인지 확인하기 위한 scrap 필드를 response dto에 추가했습니다.
- 해당 api들은 비로그인 사용자도 사용할  수 있기에, @LoginUser 커스텀 어노테이션에 required를 추가하여 비로그인 사용자일 경우에는 모두 false를 return하고 로그인 사용자인 경우에는 저장여부를 확인하고 true/false를 return 하도록 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 식당·리뷰 스크랩(북마크) 기능 및 사용자별 스크랩 표시 추가
  * 홈용 코카지 리뷰용 응답 타입 추가

* **개선**
  * 비로그인 상태에서 일부 엔드포인트 접근 허용(선택적 로그인)
  * 식당 최신 기준을 코카지 등록 시간 기준으로 정렬 개선

* **기타**
  * 사용자별 스크랩 조회로 응답에 scrap 플래그 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->