### PR TITLE
[FEAT] 사장님 가게 목록 조회 및 콜키지 추가/수정 기능 추가 개발

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
@@ -266,7 +266,7 @@ public class BookmarkGroupService {
                 restaurants.stream()
                         .map(restaurant -> {
                             List<String> imageUrls =
-                                    imageRepository.findByCategoryAndTypeId(
+                                    imageRepository.findAllByCategoryAndTypeId(
                                                     ImageCategory.RESTAURANT,
                                                     restaurant.getRestaurantId()
                                             ).stream()

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkService.java
@@ -274,7 +274,7 @@ public class BookmarkService {
                     Restaurant restaurant = restaurantRepository
                             .findById(bookmark.getTargetId())
                             .orElseThrow(() -> new CustomException(RESTAURANT_NOT_FOUND));
-                    List<Image> images = imageRepository.findByCategoryAndTypeId(
+                    List<Image> images = imageRepository.findAllByCategoryAndTypeId(
                             ImageCategory.RESTAURANT,
                             restaurant.getRestaurantId()
                     );

--- a/src/main/java/konkuk/corkCharge/domain/corkageStore/controller/CorkageStoreController.java
+++ b/src/main/java/konkuk/corkCharge/domain/corkageStore/controller/CorkageStoreController.java
@@ -31,7 +31,7 @@ public class CorkageStoreController {
     @GetMapping("/verify")
     public BaseResponse<List<GetCorkageVerificationResponse>> requestCorkage(
             @LoginUserId Long userId
-    ){
+    ) {
         return BaseResponse.ok(corkageStoreService.requestCorkage(userId));
     }
 

--- a/src/main/java/konkuk/corkCharge/domain/corkageStore/controller/CorkageStoreController.java
+++ b/src/main/java/konkuk/corkCharge/domain/corkageStore/controller/CorkageStoreController.java
@@ -20,11 +20,11 @@ public class CorkageStoreController {
     private final CorkageStoreService corkageStoreService;
 
     @PostMapping
-    public BaseResponse<Void> createCorkage(
+    public BaseResponse<Void> createOrUpdateCorkage(
             @LoginUserId Long userId,
             @RequestBody PostAddCorkageRequest request
     ) {
-        corkageStoreService.createCorkage(userId, request);
+        corkageStoreService.createOrUpdateCorkage(userId, request);
         return BaseResponse.ok(null);
     }
 

--- a/src/main/java/konkuk/corkCharge/domain/corkageStore/domain/CorkageStore.java
+++ b/src/main/java/konkuk/corkCharge/domain/corkageStore/domain/CorkageStore.java
@@ -64,4 +64,21 @@ public class CorkageStore extends BaseEntity {
         this.corkageType = corkageType;
         this.corkagePrice = corkagePrice;
     }
+
+    public void updateCorkageType(CorkageType corkageType) {
+        this.corkageType = corkageType;
+    }
+
+    public void updateCorkagePrice(Integer corkagePrice) {
+        this.corkagePrice = corkagePrice;
+    }
+
+    public void resetOptionBits() {
+        this.optionBits = 0;
+    }
+
+    public void clearEtcContent() {
+        this.etcContent = null;
+    }
+
 }

--- a/src/main/java/konkuk/corkCharge/domain/corkageStore/dto/response/GetCorkageVerificationResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/corkageStore/dto/response/GetCorkageVerificationResponse.java
@@ -4,6 +4,6 @@ public record GetCorkageVerificationResponse(
         Long restaurantId,
         String restaurantName,
         String address,
-        String thumbnailUrl
+        String mainImageUrl
 ) {
 }

--- a/src/main/java/konkuk/corkCharge/domain/corkageStore/repository/MultiCorkageRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/corkageStore/repository/MultiCorkageRepository.java
@@ -2,8 +2,15 @@ package konkuk.corkCharge.domain.corkageStore.repository;
 
 import konkuk.corkCharge.domain.corkageStore.domain.MultiCorkage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MultiCorkageRepository extends JpaRepository<MultiCorkage, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from MultiCorkage mc where mc.corkageStore.corkageStoreId = :corkageStoreId")
+    void deleteAllByCorkageStoreId(@Param("corkageStoreId") Long corkageStoreId);
 }

--- a/src/main/java/konkuk/corkCharge/domain/corkageStore/service/CorkageStoreService.java
+++ b/src/main/java/konkuk/corkCharge/domain/corkageStore/service/CorkageStoreService.java
@@ -15,7 +15,9 @@ import konkuk.corkCharge.domain.image.repository.ImageRepository;
 import konkuk.corkCharge.domain.ownerRestaurant.domain.OwnerRestaurant;
 import konkuk.corkCharge.domain.ownerRestaurant.repository.OwnerRestaurantRepository;
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
+import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
 import konkuk.corkCharge.domain.restaurant.repository.RestaurantRepository;
+import konkuk.corkCharge.domain.restaurant.service.RestaurantSummaryService;
 import konkuk.corkCharge.domain.user.domain.Role;
 import konkuk.corkCharge.domain.user.domain.User;
 import konkuk.corkCharge.domain.user.repository.UserRepository;
@@ -38,6 +40,7 @@ public class CorkageStoreService {
     private final UserRepository userRepository;
     private final OwnerRestaurantRepository ownerRestaurantRepository;
     private final ImageRepository imageRepository;
+    private final RestaurantSummaryService restaurantSummaryService;
 
     @Transactional
     public void createCorkage(Long userId, PostAddCorkageRequest request) {
@@ -102,31 +105,21 @@ public class CorkageStoreService {
         userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        List<OwnerRestaurant> mappings = ownerRestaurantRepository.findAllByUser_UserIdAndRestaurant_HasCorkageFalse(userId);
+        List<Long> restaurantIds = ownerRestaurantRepository.findRestaurantIdsByUserId(userId);
 
-        if(mappings.isEmpty()){
-            throw new CustomException(PERMISSION_DENIED);
+        if (restaurantIds.isEmpty()) {
+            return List.of();
         }
 
-        return mappings.stream()
-                .map(OwnerRestaurant::getRestaurant)
-                .map(restaurant -> {
-                    String thumbnailUrl = imageRepository
-                            .findFirstByCategoryAndTypeIdAndType(
-                                    ImageCategory.RESTAURANT,
-                                    restaurant.getRestaurantId(),
-                                    ImageType.MAIN
-                            )
-                            .map(Image::getImageUrl)
-                            .orElse(null);
+        List<RestaurantSummary> summaries = restaurantSummaryService.getSummariesInOrder(restaurantIds);
 
-                    return new GetCorkageVerificationResponse(
-                            restaurant.getRestaurantId(),
-                            restaurant.getName(),
-                            restaurant.getAddress(),
-                            thumbnailUrl
-                    );
-                })
+        return summaries.stream()
+                .map(summary -> new GetCorkageVerificationResponse(
+                        summary.getRestaurantId(),
+                        summary.getName(),
+                        summary.getAddress(),
+                        summary.getMainImageUrl()
+                ))
                 .toList();
     }
 

--- a/src/main/java/konkuk/corkCharge/domain/corkageStore/service/CorkageStoreService.java
+++ b/src/main/java/konkuk/corkCharge/domain/corkageStore/service/CorkageStoreService.java
@@ -12,7 +12,6 @@ import konkuk.corkCharge.domain.image.domain.Image;
 import konkuk.corkCharge.domain.image.domain.ImageCategory;
 import konkuk.corkCharge.domain.image.domain.ImageType;
 import konkuk.corkCharge.domain.image.repository.ImageRepository;
-import konkuk.corkCharge.domain.ownerRestaurant.domain.OwnerRestaurant;
 import konkuk.corkCharge.domain.ownerRestaurant.repository.OwnerRestaurantRepository;
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
 import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
@@ -28,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static konkuk.corkCharge.domain.corkageStore.domain.OptionType.ETC;
 import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.*;
 
 @Service
@@ -43,61 +43,126 @@ public class CorkageStoreService {
     private final RestaurantSummaryService restaurantSummaryService;
 
     @Transactional
-    public void createCorkage(Long userId, PostAddCorkageRequest request) {
+    public void createOrUpdateCorkage(Long userId, PostAddCorkageRequest request) {
+        if (request == null || request.restaurantId() == null) {
+            throw new CustomException(BAD_REQUEST);
+        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        if (user.getRole() == Role.USER) {
+        if (user.getRole() != Role.OWNER) {
             throw new CustomException(PERMISSION_DENIED);
         }
 
         Restaurant restaurant = restaurantRepository.findById(request.restaurantId())
                 .orElseThrow(() -> new CustomException(RESTAURANT_NOT_FOUND));
 
-        if (restaurant.isHasCorkage()) {
-            throw new CustomException(ALREADY_REGISTERED_CORKAGE);
+        boolean isMyRestaurant = ownerRestaurantRepository.existsByRestaurant(restaurant);
+        if (!isMyRestaurant) {
+            throw new CustomException(PERMISSION_DENIED);
         }
 
-        CorkageType corkageType = CorkageType.valueOf(request.corkageType());
+        // 콜키지 타입
+        CorkageType newType = CorkageType.valueOf(request.corkageType());
 
-        CorkageStore corkageStore = CorkageStore.builder()
-                .restaurant(restaurant)
-                .corkageType(corkageType)
-                .corkagePrice(request.corkagePrice())
-                .build();
+        // 콜키지 옵션
+        List<OptionType> optionTypes = (request.optionTypes() == null) ? List.of() : request.optionTypes().stream()
+                .map(opt -> OptionType.valueOf(opt))
+                .toList();
 
-        corkageStoreRepository.save(corkageStore);
+        CorkageStore corkageStore =
+                corkageStoreRepository.findByRestaurant_RestaurantId(request.restaurantId())
+                        .orElse(null);
 
-        if (corkageType == CorkageType.MULTIPLE && request.multiCorkages() != null) {
-            for (MultiCorkageRequest multiCorkage : request.multiCorkages()) {
-                MultiCorkage entity = MultiCorkage.builder()
-                        .liquorType(multiCorkage.liquorType())
-                        .price(multiCorkage.price())
-                        .corkageStore(corkageStore)
-                        .build();
+        boolean isNew = false;
 
-                multiCorkageRepository.save(entity);
+        if (corkageStore == null) {
+            // 콜키지 매장이 아닌 경우
+            corkageStore = CorkageStore.builder()
+                    .restaurant(restaurant)
+                    .corkageType(newType)
+                    .corkagePrice(normalizePrice(newType, request.corkagePrice()))
+                    .build();
 
-                corkageStore.getMultiPrices().add(entity);
-            }
+            corkageStoreRepository.save(corkageStore);
+            isNew = true;
         }
 
-        if (request.optionTypes() != null) {
-            List<OptionType> bitTypes = request.optionTypes().stream()
-                    .map(OptionType::valueOf)
-                    .toList();
-
-            // optionBits 저장
-            corkageStore.addOptionBits(bitTypes);
-
-            // ETC 텍스트 저장 (옵션에 ETC 포함될 때만)
-            if (bitTypes.contains(OptionType.ETC)) {
-                corkageStore.updateEtcContent(request.etcContent());
-            }
+        if (!isNew) {
+            applyTypeAndPrice(corkageStore, newType, request);
         }
 
-        restaurant.setHasCorkage(true);
+        applyMultiCorkages(corkageStore, newType, request.multiCorkages());
+
+        applyOptions(corkageStore, optionTypes, request.etcContent());
+        corkageStoreRepository.saveAndFlush(corkageStore);
+
+        if (!restaurant.isHasCorkage()) {
+            restaurant.setHasCorkage(true);
+        }
+
+        restaurantSummaryService.evictSummary(request.restaurantId());
+    }
+
+    private Integer normalizePrice(CorkageType type, Integer corkagePrice) {
+        if (type == CorkageType.FREE || type == CorkageType.MULTIPLE)
+            return 0;
+
+        return (corkagePrice == null) ? 0 : corkagePrice;
+    }
+
+    private void applyTypeAndPrice(CorkageStore corkageStore, CorkageType newType, PostAddCorkageRequest request) {
+        corkageStore.updateCorkageType(newType);
+
+        Integer price = normalizePrice(newType, request.corkagePrice());
+        corkageStore.updateCorkagePrice(price);
+    }
+
+    private void applyMultiCorkages(CorkageStore corkageStore, CorkageType newType, List<MultiCorkageRequest> multiReqs) {
+
+        Long corkageStoreId = corkageStore.getCorkageStoreId();
+        if (corkageStoreId == null) {
+            throw new CustomException(BAD_REQUEST);
+        }
+
+        if (newType != CorkageType.MULTIPLE) {
+            multiCorkageRepository.deleteAllByCorkageStoreId(corkageStoreId);
+            return;
+        }
+
+        multiCorkageRepository.deleteAllByCorkageStoreId(corkageStoreId);
+
+        for (MultiCorkageRequest r : multiReqs) {
+            String liquorType = r.liquorType();
+
+            int price = r.price();
+
+            MultiCorkage entity = MultiCorkage.builder()
+                    .liquorType(liquorType)
+                    .price(price)
+                    .corkageStore(corkageStore)
+                    .build();
+
+            multiCorkageRepository.save(entity);
+        }
+    }
+
+    private void applyOptions(CorkageStore corkageStore, List<OptionType> optionTypes, String etcContent) {
+        corkageStore.resetOptionBits();
+
+        if (optionTypes == null || optionTypes.isEmpty()) {
+            corkageStore.clearEtcContent();
+            return;
+        }
+
+        corkageStore.addOptionBits(optionTypes);
+
+        if (optionTypes.contains(ETC)) {
+            corkageStore.updateEtcContent(etcContent);
+        } else {
+            corkageStore.clearEtcContent();
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/konkuk/corkCharge/domain/corkageStore/service/CorkageStoreService.java
+++ b/src/main/java/konkuk/corkCharge/domain/corkageStore/service/CorkageStoreService.java
@@ -43,36 +43,37 @@ public class CorkageStoreService {
     private final RestaurantSummaryService restaurantSummaryService;
 
     @Transactional
-    public void createOrUpdateCorkage(Long userId, PostAddCorkageRequest request) {
-        if (request == null || request.restaurantId() == null) {
+    public void createOrUpdateCorkage(Long userId, PostAddCorkageRequest req) {
+        if (req == null || req.restaurantId() == null) {
             throw new CustomException(BAD_REQUEST);
         }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        if (user.getRole() != Role.OWNER) {
-            throw new CustomException(PERMISSION_DENIED);
-        }
-
-        Restaurant restaurant = restaurantRepository.findById(request.restaurantId())
-                .orElseThrow(() -> new CustomException(RESTAURANT_NOT_FOUND));
-
-        boolean isMyRestaurant = ownerRestaurantRepository.existsByRestaurant(restaurant);
+        boolean isMyRestaurant = ownerRestaurantRepository.existsByUser_UserIdAndRestaurant_RestaurantId(userId, req.restaurantId());
         if (!isMyRestaurant) {
             throw new CustomException(PERMISSION_DENIED);
         }
 
+        if (user.getRole() != Role.OWNER) {
+            throw new CustomException(PERMISSION_DENIED);
+        }
+
+        Restaurant restaurant = restaurantRepository.findById(req.restaurantId())
+                .orElseThrow(() -> new CustomException(RESTAURANT_NOT_FOUND));
+
+
         // 콜키지 타입
-        CorkageType newType = CorkageType.valueOf(request.corkageType());
+        CorkageType newType = CorkageType.valueOf(req.corkageType());
 
         // 콜키지 옵션
-        List<OptionType> optionTypes = (request.optionTypes() == null) ? List.of() : request.optionTypes().stream()
+        List<OptionType> optionTypes = (req.optionTypes() == null) ? List.of() : req.optionTypes().stream()
                 .map(opt -> OptionType.valueOf(opt))
                 .toList();
 
         CorkageStore corkageStore =
-                corkageStoreRepository.findByRestaurant_RestaurantId(request.restaurantId())
+                corkageStoreRepository.findByRestaurant_RestaurantId(req.restaurantId())
                         .orElse(null);
 
         boolean isNew = false;
@@ -82,7 +83,7 @@ public class CorkageStoreService {
             corkageStore = CorkageStore.builder()
                     .restaurant(restaurant)
                     .corkageType(newType)
-                    .corkagePrice(normalizePrice(newType, request.corkagePrice()))
+                    .corkagePrice(normalizePrice(newType, req.corkagePrice()))
                     .build();
 
             corkageStoreRepository.save(corkageStore);
@@ -90,19 +91,19 @@ public class CorkageStoreService {
         }
 
         if (!isNew) {
-            applyTypeAndPrice(corkageStore, newType, request);
+            applyTypeAndPrice(corkageStore, newType, req);
         }
 
-        applyMultiCorkages(corkageStore, newType, request.multiCorkages());
+        applyMultiCorkages(corkageStore, newType, req.multiCorkages());
 
-        applyOptions(corkageStore, optionTypes, request.etcContent());
+        applyOptions(corkageStore, optionTypes, req.etcContent());
         corkageStoreRepository.saveAndFlush(corkageStore);
 
         if (!restaurant.isHasCorkage()) {
             restaurant.setHasCorkage(true);
         }
 
-        restaurantSummaryService.evictSummary(request.restaurantId());
+        restaurantSummaryService.evictSummary(req.restaurantId());
     }
 
     private Integer normalizePrice(CorkageType type, Integer corkagePrice) {

--- a/src/main/java/konkuk/corkCharge/domain/image/repository/ImageRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/image/repository/ImageRepository.java
@@ -14,12 +14,19 @@ import java.util.Optional;
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
-    List<Image> findByCategoryAndTypeId(ImageCategory category, Long typeId);
+    // 이미지 여러장 단건 조회용
+    List<Image> findAllByCategoryAndTypeId(ImageCategory category, Long typeId);
 
+    // 이미지 여러장 단건 조회용 (매장 MAIN/MENU)
+    List<Image> findAllByCategoryAndTypeIdAndType(ImageCategory category, Long typeId, ImageType type);
+
+    // 이미지 한장 단건 조회용 (최신순)
     Optional<Image> findFirstByCategoryAndTypeIdOrderByCreatedAtAsc(ImageCategory category, Long typeId);
 
+    // 이미지 한장 단건 조회용 (매장 MAIN/MENU)
     Optional<Image> findFirstByCategoryAndTypeIdAndType(ImageCategory category, Long typeId, ImageType type);
 
+    // 이미지 한장 단건 조회용
     Optional<Image> findFirstByCategoryAndTypeId(ImageCategory category, Long typeId);
 
     void deleteByCategoryAndTypeId(ImageCategory category, Long typeId);

--- a/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/controller/OwnerRestaurantController.java
+++ b/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/controller/OwnerRestaurantController.java
@@ -1,5 +1,6 @@
 package konkuk.corkCharge.domain.ownerRestaurant.controller;
 
+import konkuk.corkCharge.domain.ownerRestaurant.dto.response.GetOwnerMyRestaurantListResponse;
 import konkuk.corkCharge.domain.ownerRestaurant.service.OwnerRestaurantService;
 import konkuk.corkCharge.domain.user.domain.User;
 import konkuk.corkCharge.domain.user.repository.UserRepository;
@@ -24,4 +25,12 @@ public class OwnerRestaurantController {
         ownerRestaurantService.registerRestaurant(userId, restaurantId);
         return BaseResponse.ok(null);
     }
+
+    @GetMapping("/my")
+    public BaseResponse<GetOwnerMyRestaurantListResponse> getMyRestaurants(
+            @LoginUserId Long userId
+    ) {
+        return BaseResponse.ok(ownerRestaurantService.getMyRestaurants(userId));
+    }
+
 }

--- a/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/dto/mapper/OwnerMyRestaurantResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/dto/mapper/OwnerMyRestaurantResponseMapper.java
@@ -1,0 +1,54 @@
+package konkuk.corkCharge.domain.ownerRestaurant.dto.mapper;
+
+import konkuk.corkCharge.domain.corkageStore.domain.OptionType;
+import konkuk.corkCharge.domain.ownerRestaurant.dto.response.GetOwnerMyRestaurantListResponse;
+import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class OwnerMyRestaurantResponseMapper {
+    public GetOwnerMyRestaurantListResponse.Item toItem(RestaurantSummary summary) {
+
+        String corkagePrice = summary.isHasCorkage() ? summary.getCorkagePrice() : null;
+
+        List<String> corkageOptions = summary.isHasCorkage()
+                ? decodeOptions(summary.getOptionBits(), summary.getOptionEtcContent())
+                : List.of();
+
+        return new GetOwnerMyRestaurantListResponse.Item(
+                summary.getRestaurantId(),
+                summary.getName(),
+                safeDouble(summary.getAvgRating()),
+                summary.getReviewCount() == null ? 0 : summary.getReviewCount(),
+                summary.getOpeningHours(),
+
+                corkagePrice,
+                corkageOptions,
+
+                safeList(summary.getMainImages())
+        );
+    }
+
+    private List<String> safeList(List<String> v) {
+        return v == null ? List.of() : v;
+    }
+
+    private double safeDouble(Double v) {
+        return v == null ? 0.0 : v;
+    }
+
+    private List<String> decodeOptions(Integer optionBits, String etcContent) {
+        if (optionBits == null || optionBits == 0) return List.of();
+
+        int bits = optionBits;
+
+        return Arrays.stream(OptionType.values())
+                .filter(type -> (bits & (1 << type.ordinal())) != 0)
+                .map(type -> type == OptionType.ETC ? etcContent : type.getLabel())
+                .filter(s -> s != null && !s.isBlank())
+                .toList();
+    }
+}

--- a/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/dto/response/GetOwnerMyRestaurantListResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/dto/response/GetOwnerMyRestaurantListResponse.java
@@ -1,0 +1,21 @@
+package konkuk.corkCharge.domain.ownerRestaurant.dto.response;
+
+import java.util.List;
+
+public record GetOwnerMyRestaurantListResponse(
+        List<Item> items
+) {
+    public record Item(
+            Long restaurantId,
+            String restaurantName,
+            Double rating,
+            Integer totalReviewCount,
+            String openingHours,
+
+            // hasCorkage=false면 null / 빈값 가능
+            String corkagePrice,
+            List<String> corkageOptions,
+
+            List<String> mainImages
+    ) { }
+}

--- a/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/repository/OwnerRestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/repository/OwnerRestaurantRepository.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 @Repository
 public interface OwnerRestaurantRepository extends JpaRepository<OwnerRestaurant, Long> {
     boolean existsByRestaurant(Restaurant restaurant);
-    List<OwnerRestaurant> findAllByUser_UserIdAndRestaurant_HasCorkageFalse(Long userId);
 
     @Query("""
         select orr.restaurant.restaurantId

--- a/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/repository/OwnerRestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/repository/OwnerRestaurantRepository.java
@@ -21,4 +21,7 @@ public interface OwnerRestaurantRepository extends JpaRepository<OwnerRestaurant
          order by orr.createdAt desc, orr.id desc
     """)
     List<Long> findRestaurantIdsByUserId(@Param("userId") Long userId);
+
+    boolean existsByUser_UserIdAndRestaurant_RestaurantId(Long userId, Long restaurantId);
+
 }

--- a/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/repository/OwnerRestaurantRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/repository/OwnerRestaurantRepository.java
@@ -3,6 +3,8 @@ package konkuk.corkCharge.domain.ownerRestaurant.repository;
 import konkuk.corkCharge.domain.ownerRestaurant.domain.OwnerRestaurant;
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +14,12 @@ import java.util.Optional;
 public interface OwnerRestaurantRepository extends JpaRepository<OwnerRestaurant, Long> {
     boolean existsByRestaurant(Restaurant restaurant);
     List<OwnerRestaurant> findAllByUser_UserIdAndRestaurant_HasCorkageFalse(Long userId);
+
+    @Query("""
+        select orr.restaurant.restaurantId
+          from OwnerRestaurant orr
+         where orr.user.userId = :userId
+         order by orr.createdAt desc, orr.id desc
+    """)
+    List<Long> findRestaurantIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/service/OwnerRestaurantService.java
+++ b/src/main/java/konkuk/corkCharge/domain/ownerRestaurant/service/OwnerRestaurantService.java
@@ -1,14 +1,22 @@
 package konkuk.corkCharge.domain.ownerRestaurant.service;
 
 import konkuk.corkCharge.domain.ownerRestaurant.domain.OwnerRestaurant;
+import konkuk.corkCharge.domain.ownerRestaurant.dto.mapper.OwnerMyRestaurantResponseMapper;
+import konkuk.corkCharge.domain.ownerRestaurant.dto.response.GetOwnerMyRestaurantListResponse;
 import konkuk.corkCharge.domain.ownerRestaurant.repository.OwnerRestaurantRepository;
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
+import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
 import konkuk.corkCharge.domain.restaurant.repository.RestaurantRepository;
+import konkuk.corkCharge.domain.restaurant.service.RestaurantSummaryService;
+import konkuk.corkCharge.domain.user.domain.Role;
 import konkuk.corkCharge.domain.user.domain.User;
 import konkuk.corkCharge.domain.user.repository.UserRepository;
 import konkuk.corkCharge.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.*;
 
@@ -19,7 +27,10 @@ public class OwnerRestaurantService {
     private final OwnerRestaurantRepository ownerRestaurantRepository;
     private final UserRepository userRepository;
     private final RestaurantRepository restaurantRepository;
+    private final RestaurantSummaryService restaurantSummaryService;
+    private final OwnerMyRestaurantResponseMapper ownerMyRestaurantResponseMapper;
 
+    @Transactional
     public void registerRestaurant(Long userId, Long restaurantId){
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -38,4 +49,28 @@ public class OwnerRestaurantService {
 
         ownerRestaurantRepository.save(ownerRestaurant);
     }
+
+    @Transactional(readOnly = true)
+    public GetOwnerMyRestaurantListResponse getMyRestaurants(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (user.getRole() != Role.OWNER) {
+            throw new CustomException(ACCESS_DENIED);
+        }
+
+        List<Long> restaurantIds = ownerRestaurantRepository.findRestaurantIdsByUserId(userId);
+        if (restaurantIds.isEmpty()) {
+            return new GetOwnerMyRestaurantListResponse(List.of());
+        }
+
+        List<RestaurantSummary> summaries = restaurantSummaryService.getSummariesInOrder(restaurantIds);
+
+        List<GetOwnerMyRestaurantListResponse.Item> items = summaries.stream()
+                .map(ownerMyRestaurantResponseMapper::toItem)
+                .toList();
+
+        return new GetOwnerMyRestaurantListResponse(items);
+    }
+
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/domain/RestaurantSummary.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/domain/RestaurantSummary.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
+import java.util.List;
 
 @Getter
 @Builder
@@ -23,10 +24,15 @@ public class RestaurantSummary implements Serializable {
     private String representMenu;
     private String openingHours;
 
-    // 이미지
+    // 이미지(대표 1장)
     private String mainImageUrl;
     private String menuImageUrl;
-    private String pairingImageUrl; // corkage pairing 대표 이미지
+    private String pairingImageUrl;
+
+    // 이미지(여러장)
+    private List<String> mainImages;
+    private List<String> menuImages;
+    private List<String> pairingImages;
 
     // 리뷰
     private Integer reviewCount;

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantSummaryService.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/service/RestaurantSummaryService.java
@@ -29,11 +29,6 @@ public class RestaurantSummaryService {
     private final CorkageStoreRepository corkageStoreRepository;
     private final ImageRepository imageRepository;
 
-
-    /**
-     * 레스토랑 요약 정보를 Redis에 캐싱.
-     * cacheNames = "restaurantSummary"
-     */
     @Transactional(readOnly = true)
     @Cacheable(cacheNames = "restaurantSummary", key = "#p0")
     public RestaurantSummary getSummary(Long restaurantId) {
@@ -41,101 +36,93 @@ public class RestaurantSummaryService {
         Restaurant restaurant = restaurantRepository.findById(restaurantId)
                 .orElseThrow(() -> new CustomException(RESTAURANT_NOT_FOUND));
 
-        // 1. 이미지 (메인/메뉴)
-        String mainImageUrl = imageRepository
-                .findFirstByCategoryAndTypeIdAndType(ImageCategory.RESTAURANT, restaurantId, ImageType.MAIN)
-                .map(Image::getImageUrl)
-                .orElse(null);
+        // RESTAURANT images
+        List<Image> mainImageEntities = imageRepository
+                .findAllByCategoryAndTypeIdAndType(ImageCategory.RESTAURANT, restaurantId, ImageType.MAIN)
+                .stream()
+                .sorted(Comparator.comparing(Image::getCreatedAt))
+                .toList();
 
-        String menuImageUrl = imageRepository
-                .findFirstByCategoryAndTypeIdAndType(ImageCategory.RESTAURANT, restaurantId, ImageType.MENU)
-                .map(Image::getImageUrl)
-                .orElse(null);
+        List<Image> menuImageEntities = imageRepository
+                .findAllByCategoryAndTypeIdAndType(ImageCategory.RESTAURANT, restaurantId, ImageType.MENU)
+                .stream()
+                .sorted(Comparator.comparing(Image::getCreatedAt))
+                .toList();
 
-        // 2. 콜키지 정보
+        List<String> mainImages = mainImageEntities.stream().map(Image::getImageUrl).toList();
+        List<String> menuImages = menuImageEntities.stream().map(Image::getImageUrl).toList();
+
+        String mainImage = firstOrNull(mainImages);
+        String menuImage = firstOrNull(menuImages);
+
         CorkageStore corkage = corkageStoreRepository
                 .findByRestaurant_RestaurantId(restaurantId)
                 .orElse(null);
+
+        List<String> pairingImages = List.of();
+        String pairingImage = null;
 
         String corkagePrice = null;
         Integer optionBits = null;
         String optionEtcContent = null;
         String pairingAlcohol = null;
         String pairingDescription = null;
-        String pairingImageUrl = null;
         CorkageType corkageType = null;
 
         if (corkage != null) {
+            List<Image> pairingImageEntities = imageRepository
+                    .findAllByCategoryAndTypeId(ImageCategory.CORKAGE, corkage.getCorkageStoreId())
+                    .stream()
+                    .sorted(Comparator.comparing(Image::getCreatedAt))
+                    .toList();
 
-            // pairing 이미지
-            pairingImageUrl = imageRepository
-                    .findFirstByCategoryAndTypeId(ImageCategory.CORKAGE, corkage.getCorkageStoreId())
-                    .map(Image::getImageUrl)
-                    .orElse(null);
+            pairingImages = pairingImageEntities.stream().map(Image::getImageUrl).toList();
+            pairingImage = firstOrNull(pairingImages);
 
             corkageType = corkage.getCorkageType();
+            corkagePrice = buildCorkagePrice(corkage);
 
-            // 콜키지 가격 문자열 생성
-            if (corkageType == CorkageType.MULTIPLE) {
-                corkagePrice = corkage.getMultiPrices().stream()
-                        .map(mp -> mp.getLiquorType() + " 병당: " + mp.getPrice() + "원")
-                        .collect(Collectors.joining(", "));
-            } else if (corkageType == CorkageType.FREE) {
-                corkagePrice = "콜키지 프리";
-            } else {
-                corkagePrice = switch (corkageType) {
-                    case PER_BOTTLE -> "병당 " + corkage.getCorkagePrice() + "원";
-                    case PER_PERSON -> "인당 " + corkage.getCorkagePrice() + "원";
-                    case PER_TABLE -> "테이블당 " + corkage.getCorkagePrice() + "원";
-                    default -> null;
-                };
-            }
-
-            // 옵션 비트 / ETC 내용
             optionBits = corkage.getOptionBits();
-            optionEtcContent = corkage.getEtcContent();    // ETC 텍스트 (있다면)
+            optionEtcContent = corkage.getEtcContent();
 
-            // ---- 페어링 ----
             pairingAlcohol = corkage.getPairing();
             pairingDescription = corkage.getDescription();
         }
 
-        // Summary 생성
         return RestaurantSummary.builder()
                 .restaurantId(restaurantId)
                 .name(restaurant.getName())
 
-                // 기본 정보
                 .address(restaurant.getAddress())
                 .phone(restaurant.getPhone())
                 .representMenu(restaurant.getRepresentMenu())
                 .openingHours(restaurant.getOpeningHours())
 
-                // 이미지
-                .mainImageUrl(mainImageUrl)
-                .menuImageUrl(menuImageUrl)
-                .pairingImageUrl(pairingImageUrl)
+                // 이미지 (리스트)
+                .mainImages(mainImages)
+                .menuImages(menuImages)
+                .pairingImages(pairingImages)
 
-                // 리뷰 / 북마크
+                // 이미지 (1장)
+                .mainImageUrl(mainImage)
+                .menuImageUrl(menuImage)
+                .pairingImageUrl(pairingImage)
+
                 .reviewCount(restaurant.getReviewCount())
                 .avgRating(restaurant.getRating())
                 .bookmarkCount(restaurant.getBookmarkCount())
 
-                // 콜키지
                 .hasCorkage(restaurant.isHasCorkage())
                 .corkageType(corkageType)
                 .corkagePrice(corkagePrice)
                 .optionBits(optionBits)
                 .optionEtcContent(optionEtcContent)
 
-                // 페어링
                 .pairingAlcohol(pairingAlcohol)
                 .pairingDescription(pairingDescription)
 
-                // 위치
                 .latitude(restaurant.getLatitude())
                 .longitude(restaurant.getLongitude())
-
                 .build();
     }
 
@@ -153,43 +140,79 @@ public class RestaurantSummaryService {
         Map<Long, CorkageStore> corkageMap = corkageStores.stream()
                 .collect(Collectors.toMap(cs -> cs.getRestaurant().getRestaurantId(), cs -> cs));
 
-        // 3) RESTAURANT 이미지
+        // 3) RESTAURANT 이미지 bulk
         List<Image> restaurantImages = imageRepository.findRestaurantImagesByRestaurantIds(restaurantIds);
 
-        Map<Long, String> mainImageMap = new HashMap<>();
-        Map<Long, String> menuImageMap = new HashMap<>();
-        for (Image img : restaurantImages) {
-            if (img.getType() == ImageType.MAIN) mainImageMap.putIfAbsent(img.getTypeId(), img.getImageUrl());
-            if (img.getType() == ImageType.MENU) menuImageMap.putIfAbsent(img.getTypeId(), img.getImageUrl());
-        }
+        List<Image> sortedRestaurantImages = restaurantImages.stream()
+                .sorted(Comparator.comparing(Image::getCreatedAt))
+                .toList();
 
-        // 4) CORKAGE 이미지
+        Map<Long, List<String>> mainImagesMap = sortedRestaurantImages.stream()
+                .filter(img -> img.getType() == ImageType.MAIN)
+                .collect(Collectors.groupingBy(
+                        Image::getTypeId,
+                        LinkedHashMap::new,
+                        Collectors.mapping(Image::getImageUrl, Collectors.toList())
+                ));
+
+        Map<Long, List<String>> menuImagesMap = sortedRestaurantImages.stream()
+                .filter(img -> img.getType() == ImageType.MENU)
+                .collect(Collectors.groupingBy(
+                        Image::getTypeId,
+                        LinkedHashMap::new,
+                        Collectors.mapping(Image::getImageUrl, Collectors.toList())
+                ));
+
+        // 4) CORKAGE 이미지 bulk
         List<Long> corkageIds = corkageStores.stream()
                 .map(CorkageStore::getCorkageStoreId)
                 .toList();
 
-        Map<Long, String> corkageImageMap = new HashMap<>();
+        Map<Long, List<String>> pairingImagesMap = new HashMap<>();
         if (!corkageIds.isEmpty()) {
             List<Image> corkageImages = imageRepository.findCorkageImagesByCorkageIds(corkageIds);
-            for (Image img : corkageImages) {
-                // typeId = corkageStoreId
-                corkageImageMap.putIfAbsent(img.getTypeId(), img.getImageUrl());
-            }
+
+            List<Image> sortedCorkageImages = corkageImages.stream()
+                    .sorted(Comparator.comparing(Image::getCreatedAt))
+                    .toList();
+
+            pairingImagesMap = sortedCorkageImages.stream()
+                    .collect(Collectors.groupingBy(
+                            Image::getTypeId, // corkage_store_id
+                            LinkedHashMap::new,
+                            Collectors.mapping(Image::getImageUrl, Collectors.toList())
+                    ));
         }
 
         // 5) 순서 유지
         List<RestaurantSummary> result = new ArrayList<>(restaurantIds.size());
-        for (Long id : restaurantIds) {
-            Restaurant restaurant = restaurantMap.get(id);
+
+        for (Long restaurantId : restaurantIds) {
+            Restaurant restaurant = restaurantMap.get(restaurantId);
             if (restaurant == null) continue;
 
-            CorkageStore corkage = corkageMap.get(id);
+            CorkageStore corkage = corkageMap.get(restaurantId);
 
-            String main = mainImageMap.get(id);
-            String menu = menuImageMap.get(id);
-            String pairing = (corkage == null) ? null : corkageImageMap.get(corkage.getCorkageStoreId());
+            List<String> mainImages = mainImagesMap.getOrDefault(restaurantId, List.of());
+            List<String> menuImages = menuImagesMap.getOrDefault(restaurantId, List.of());
 
-            result.add(buildSummary(restaurant, corkage, main, menu, pairing));
+            String mainImage = firstOrNull(mainImages);
+            String menuImage = firstOrNull(menuImages);
+
+            List<String> pairingImages = List.of();
+            String pairingImage = null;
+
+            if (corkage != null) {
+                pairingImages = pairingImagesMap.getOrDefault(corkage.getCorkageStoreId(), List.of());
+                pairingImage = firstOrNull(pairingImages);
+            }
+
+            result.add(buildSummary(
+                    restaurant,
+                    corkage,
+                    mainImages, menuImages, pairingImages,
+                    mainImage, menuImage, pairingImage
+            ));
         }
 
         return result;
@@ -198,9 +221,12 @@ public class RestaurantSummaryService {
     private RestaurantSummary buildSummary(
             Restaurant restaurant,
             CorkageStore corkage,
-            String mainImageUrl,
-            String menuImageUrl,
-            String pairingImageUrl
+            List<String> mainImages,
+            List<String> menuImages,
+            List<String> pairingImages,
+            String mainImage,
+            String menuImage,
+            String pairingImage
     ) {
         String corkagePrice = null;
         Integer optionBits = null;
@@ -211,24 +237,11 @@ public class RestaurantSummaryService {
 
         if (corkage != null) {
             corkageType = corkage.getCorkageType();
-
-            if (corkageType == CorkageType.MULTIPLE) {
-                corkagePrice = corkage.getMultiPrices().stream()
-                        .map(mp -> mp.getLiquorType() + " 병당: " + mp.getPrice() + "원")
-                        .collect(Collectors.joining(", "));
-            } else if (corkageType == CorkageType.FREE) {
-                corkagePrice = "콜키지 프리";
-            } else {
-                corkagePrice = switch (corkageType) {
-                    case PER_BOTTLE -> "병당 " + corkage.getCorkagePrice() + "원";
-                    case PER_PERSON -> "인당 " + corkage.getCorkagePrice() + "원";
-                    case PER_TABLE -> "테이블당 " + corkage.getCorkagePrice() + "원";
-                    default -> null;
-                };
-            }
+            corkagePrice = buildCorkagePrice(corkage);
 
             optionBits = corkage.getOptionBits();
             optionEtcContent = corkage.getEtcContent();
+
             pairingAlcohol = corkage.getPairing();
             pairingDescription = corkage.getDescription();
         }
@@ -240,22 +253,59 @@ public class RestaurantSummaryService {
                 .phone(restaurant.getPhone())
                 .representMenu(restaurant.getRepresentMenu())
                 .openingHours(restaurant.getOpeningHours())
-                .mainImageUrl(mainImageUrl)
-                .menuImageUrl(menuImageUrl)
-                .pairingImageUrl(pairingImageUrl)
+
+                // 리스트
+                .mainImages(mainImages == null ? List.of() : mainImages)
+                .menuImages(menuImages == null ? List.of() : menuImages)
+                .pairingImages(pairingImages == null ? List.of() : pairingImages)
+
+                // 대표 1장
+                .mainImageUrl(mainImage)
+                .menuImageUrl(menuImage)
+                .pairingImageUrl(pairingImage)
+
                 .reviewCount(restaurant.getReviewCount())
                 .avgRating(restaurant.getRating())
                 .bookmarkCount(restaurant.getBookmarkCount())
+
                 .hasCorkage(restaurant.isHasCorkage())
                 .corkageType(corkageType)
                 .corkagePrice(corkagePrice)
                 .optionBits(optionBits)
                 .optionEtcContent(optionEtcContent)
+
                 .pairingAlcohol(pairingAlcohol)
                 .pairingDescription(pairingDescription)
+
                 .latitude(restaurant.getLatitude())
                 .longitude(restaurant.getLongitude())
                 .build();
+    }
+
+    private String buildCorkagePrice(CorkageStore corkage) {
+        if (corkage == null || corkage.getCorkageType() == null) return null;
+
+        CorkageType type = corkage.getCorkageType();
+
+        if (type == CorkageType.MULTIPLE) {
+            return corkage.getMultiPrices().stream()
+                    .map(mp -> mp.getLiquorType() + " 병당: " + mp.getPrice() + "원")
+                    .collect(Collectors.joining(", "));
+        }
+
+        if (type == CorkageType.FREE) return "콜키지 프리";
+
+        Integer price = corkage.getCorkagePrice();
+        return switch (type) {
+            case PER_BOTTLE -> "병당 " + price + "원";
+            case PER_PERSON -> "인당 " + price + "원";
+            case PER_TABLE  -> "테이블당 " + price + "원";
+            default -> null;
+        };
+    }
+
+    private String firstOrNull(List<String> list) {
+        return (list == null || list.isEmpty()) ? null : list.get(0);
     }
 
     /**

--- a/src/main/java/konkuk/corkCharge/domain/review/service/ReviewService.java
+++ b/src/main/java/konkuk/corkCharge/domain/review/service/ReviewService.java
@@ -164,7 +164,7 @@ public class ReviewService {
         review.updateRating(request.rating());
 
         if (images != null && !images.isEmpty()) {
-            imageRepository.findByCategoryAndTypeId(REVIEW, reviewId)
+            imageRepository.findAllByCategoryAndTypeId(REVIEW, reviewId)
                     .forEach(img -> s3ImageService.deleteImage(img.getImageUrl()));
             imageRepository.deleteByCategoryAndTypeId(REVIEW, reviewId);
 
@@ -196,7 +196,7 @@ public class ReviewService {
         }
 
         // 이미지 삭제
-        imageRepository.findByCategoryAndTypeId(REVIEW, reviewId)
+        imageRepository.findAllByCategoryAndTypeId(REVIEW, reviewId)
                 .forEach(img -> s3ImageService.deleteImage(img.getImageUrl()));
         imageRepository.deleteByCategoryAndTypeId(REVIEW, reviewId);
 

--- a/src/main/java/konkuk/corkCharge/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/corkCharge/domain/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package konkuk.corkCharge.domain.user.controller;
 
-import konkuk.corkCharge.domain.user.domain.Role;
 import konkuk.corkCharge.domain.user.dto.request.PostRoleRequest;
 import konkuk.corkCharge.domain.user.dto.response.*;
 import konkuk.corkCharge.domain.user.service.UserService;
@@ -58,17 +57,18 @@ public class UserController {
     }
 
     @PutMapping("/role")
-    public BaseResponse<Role> updateUserRole(
+    public BaseResponse<Void> updateUserRole(
             @LoginUserId Long userId,
             @RequestBody PostRoleRequest request
     ){
-        return BaseResponse.ok(userService.updateUserRole(userId, request.role()));
+        userService.updateRoleAndNickname(userId, request.role(), request.nickname());
+        return BaseResponse.ok(null);
     }
 
     @PutMapping("/registration")
     public BaseResponse<Void> updateRegistration(
             @LoginUserId Long userId,
-            @RequestPart(required = false) MultipartFile image
+            @RequestPart MultipartFile image
     ){
         userService.updateRegistration(userId, image);
         return BaseResponse.ok(null);
@@ -78,9 +78,7 @@ public class UserController {
     public BaseResponse<GetMyHelpRequestsResponse> getMyHelpRequests(
             @LoginUserId Long userId
     ) {
-        return BaseResponse.ok(
-                userService.getMyHelpRequests(userId)
-        );
+        return BaseResponse.ok(userService.getMyHelpRequests(userId));
     }
 
     @GetMapping("/helprequests/{helprequestId}")
@@ -88,9 +86,7 @@ public class UserController {
             @LoginUserId Long userId,
             @PathVariable Long helprequestId
     ) {
-        return BaseResponse.ok(
-                userService.getMyHelpRequestDetail(userId, helprequestId)
-        );
+        return BaseResponse.ok(userService.getMyHelpRequestDetail(userId, helprequestId));
     }
 
 }

--- a/src/main/java/konkuk/corkCharge/domain/user/domain/User.java
+++ b/src/main/java/konkuk/corkCharge/domain/user/domain/User.java
@@ -30,16 +30,7 @@ public class User extends BaseEntity {
     @Column(name = "role")
     private Role role;
 
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Review> reviews = new ArrayList<>();
-//
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<HelpRequest> helpRequests = new ArrayList<>();
-//
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
-//    private List<OwnerRestaurant> ownerRestaurants = new ArrayList<>();
-//
-//    public void addReview(Review review) {
-//        reviews.add(review);
-//    }
+    @Column(name = "nickname", length = 30)
+    private String nickname;
+
 }

--- a/src/main/java/konkuk/corkCharge/domain/user/dto/request/PostRoleRequest.java
+++ b/src/main/java/konkuk/corkCharge/domain/user/dto/request/PostRoleRequest.java
@@ -3,6 +3,7 @@ package konkuk.corkCharge.domain.user.dto.request;
 import konkuk.corkCharge.domain.user.domain.Role;
 
 public record PostRoleRequest(
-        Role role
+        Role role,
+        String nickname
 ) {
 }

--- a/src/main/java/konkuk/corkCharge/domain/user/repository/UserRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User,Long> {
 
     Optional<User> findBySocialId(String socialId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/konkuk/corkCharge/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/corkCharge/domain/user/service/UserService.java
@@ -3,8 +3,6 @@ package konkuk.corkCharge.domain.user.service;
 import konkuk.corkCharge.domain.helpRequest.domain.HelpRequest;
 import konkuk.corkCharge.domain.helpRequest.repository.HelpRequestRepository;
 import konkuk.corkCharge.domain.image.domain.Image;
-import konkuk.corkCharge.domain.image.domain.ImageCategory;
-import konkuk.corkCharge.domain.image.domain.ImageType;
 import konkuk.corkCharge.domain.image.repository.ImageRepository;
 import konkuk.corkCharge.domain.image.service.S3ImageService;
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
@@ -25,7 +23,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static konkuk.corkCharge.domain.image.domain.ImageCategory.*;
-import static konkuk.corkCharge.domain.image.domain.ImageType.MAIN;
 import static konkuk.corkCharge.global.response.status.BaseExceptionResponseStatus.*;
 
 @Service
@@ -120,21 +117,33 @@ public class UserService {
     }
 
     @Transactional
-    public Role updateUserRole(Long userId, Role role){
+    public void updateRoleAndNickname(Long userId, Role role, String nickname){
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
+        if (role == null) {
+            throw new CustomException(ROLE_REQUIRED);
+        }
+
+        if (nickname == null || nickname.isBlank()) {
+            throw new CustomException(NICKNAME_REQUIRED);
+        }
+
+        if (userRepository.existsByNickname(nickname.trim())) {
+            throw new CustomException(DUPLICATE_NICKNAME);
+        }
+
         user.setRole(role);
-        return role;
+        user.setNickname(nickname.trim());
     }
 
     @Transactional
     public void updateRegistration(Long userId, MultipartFile registrationImage) {
-        User user = userRepository.findById(userId)
+        userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         if (registrationImage == null || registrationImage.isEmpty()) {
-            return;
+            throw new CustomException(IMAGE_REQUIRED);
         }
 
         String imageUrl = s3ImageService

--- a/src/main/java/konkuk/corkCharge/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/konkuk/corkCharge/global/response/status/BaseExceptionResponseStatus.java
@@ -32,6 +32,11 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      */
     USER_NOT_FOUND(70000, "해당 사용자를 찾을 수 없습니다."),
     PERMISSION_DENIED(70001, "ADMIN 혹은 OWNER 권한이 필요합니다."),
+    ROLE_REQUIRED(70002, "사용자 권한 입력은 필수입니다."),
+    NICKNAME_REQUIRED(70003, "닉네임 입력은 필수입니다."),
+    DUPLICATE_NICKNAME(70004, "이미 사용중인 닉네임입니다."),
+    IMAGE_REQUIRED(70005, "사업자등록증 사진 첨부는 필수입니다."),
+    ACCESS_DENIED(70006, "접속 권한이 제한되었습니다."),
 
     /**
      * 80000 : Image


### PR DESCRIPTION
## #️⃣연관된 이슈

#135 

## 📝작업 내용
- redis에서 매장/메뉴/페어링 이미지를 단건으로만 저장했는데, 단건 + 벌크 조회가 가능하도록 변경
- 유저 권한추가 로직에서 nickname도 받도록 수정
- 기존 콜키지 매장이 아닌 매장을 콜키지 매장으로 "콜키지 추가하기" 기능 -> 콜키지 매장인 것도 수정이 가능하도록 "콜키지 추가/수정" 기능으로 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리즈 노트

* **New Features**
  * 소유자가 보유한 레스토랑 목록 조회 기능이 추가되었습니다.
  * 사용자 프로필에 닉네임 설정 기능이 추가되었습니다.

* **Improvements**
  * 와인 서빙료 생성/업데이트가 통합되어 관리가 간편해졌습니다.
  * 레스토랑/리뷰 이미지가 목록 단위로 제공되어 갤러리 형태의 이미지 노출이 향상되었습니다.
  * 권한 검증과 입력 검사가 강화되어 오류 안내가 명확해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->