### PR TITLE
[FEAT] 매장별 그룹 포함 여부 조회 API 개발

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/bookmark/controller/BookmarkGroupController.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/controller/BookmarkGroupController.java
@@ -3,10 +3,7 @@ package konkuk.corkCharge.domain.bookmark.controller;
 import konkuk.corkCharge.domain.bookmark.domain.BookmarkGroupSort;
 import konkuk.corkCharge.domain.bookmark.dto.request.PostBookmarkGroupRequest;
 import konkuk.corkCharge.domain.bookmark.dto.request.PutBookmarkGroupRequest;
-import konkuk.corkCharge.domain.bookmark.dto.response.GetBookmarkGroupDetailResponse;
-import konkuk.corkCharge.domain.bookmark.dto.response.GetBookmarkGroupListResponse;
-import konkuk.corkCharge.domain.bookmark.dto.response.PostBookmarkGroupResponse;
-import konkuk.corkCharge.domain.bookmark.dto.response.PutBookmarkGroupResponse;
+import konkuk.corkCharge.domain.bookmark.dto.response.*;
 import konkuk.corkCharge.domain.bookmark.service.BookmarkGroupService;
 import konkuk.corkCharge.global.annotation.LoginUserId;
 import konkuk.corkCharge.global.response.BaseResponse;
@@ -68,6 +65,16 @@ public class BookmarkGroupController {
     ) {
         return BaseResponse.ok(
                 bookmarkGroupService.getGroupDetail(userId, groupId, sort)
+        );
+    }
+
+    @GetMapping("/restaurants/{restaurantId}")
+    public BaseResponse<GetRestaurantBookmarkGroupListResponse> getGroupsByRestaurant(
+            @LoginUserId Long userId,
+            @PathVariable Long restaurantId
+    ) {
+        return BaseResponse.ok(
+                bookmarkGroupService.getBookmarkGroupsByRestaurant(userId, restaurantId)
         );
     }
 }

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/dto/response/GetRestaurantBookmarkGroupItemResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/dto/response/GetRestaurantBookmarkGroupItemResponse.java
@@ -1,0 +1,16 @@
+package konkuk.corkCharge.domain.bookmark.dto.response;
+
+import konkuk.corkCharge.domain.bookmark.domain.BookmarkGroupVisibility;
+
+import java.time.LocalDateTime;
+
+public record GetRestaurantBookmarkGroupItemResponse(
+        Long groupId,
+        String name,
+        String color,
+        BookmarkGroupVisibility visibility,
+        boolean storedFlag,
+        long storeCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/dto/response/GetRestaurantBookmarkGroupListResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/dto/response/GetRestaurantBookmarkGroupListResponse.java
@@ -1,0 +1,9 @@
+package konkuk.corkCharge.domain.bookmark.dto.response;
+
+import java.util.List;
+
+public record GetRestaurantBookmarkGroupListResponse(
+        int totalGroupCount,
+        List<GetRestaurantBookmarkGroupItemResponse> groups
+) {
+}

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/repository/RestaurantBookmarkGroupItemRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/repository/RestaurantBookmarkGroupItemRepository.java
@@ -1,6 +1,7 @@
 package konkuk.corkCharge.domain.bookmark.repository;
 
 import konkuk.corkCharge.domain.bookmark.domain.Bookmark;
+import konkuk.corkCharge.domain.bookmark.domain.BookmarkTargetType;
 import konkuk.corkCharge.domain.bookmark.domain.RestaurantBookmarkGroupItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +16,11 @@ public interface RestaurantBookmarkGroupItemRepository extends JpaRepository<Res
     long countByBookmark_Id(Long bookmarkId);
     void deleteAllByGroup_Id(Long groupId);
     int countByGroup_Id(Long groupId);
+    boolean existsByGroup_IdAndBookmark_TargetTypeAndBookmark_TargetId(
+            Long groupId,
+            BookmarkTargetType targetType,
+            Long targetId
+    );
     boolean existsByBookmark_IdAndGroup_Id(Long bookmarkId, Long groupId);
 
     @Query(value = """

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
@@ -309,14 +309,19 @@ public class BookmarkGroupService {
     }
 
     public GetRestaurantBookmarkGroupListResponse getBookmarkGroupsByRestaurant(
-            User user,
+            Long userId,
             Long restaurantId
     ) {
+        if(!userRepository.findById(userId).isPresent()) {
+            throw new CustomException(USER_NOT_FOUND);
+        }
+        if (!restaurantRepository.existsById(restaurantId)) {
+            throw new CustomException(RESTAURANT_NOT_FOUND);
+        }
+
         // 유저의 모든 그룹 조회 (정렬 포함)
         List<RestaurantBookmarkGroup> groups =
-                groupRepository.findAllByUser_UserIdOrderByDisplayOrderAsc(
-                        user.getUserId()
-                );
+                groupRepository.findAllByUser_UserIdOrderByDisplayOrderAsc(userId);
 
         // 그룹별 storedFlag + storeCount 계산
         List<GetRestaurantBookmarkGroupItemResponse> groupResponses =

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
@@ -3,10 +3,7 @@ package konkuk.corkCharge.domain.bookmark.service;
 import konkuk.corkCharge.domain.bookmark.domain.*;
 import konkuk.corkCharge.domain.bookmark.dto.request.PostBookmarkGroupRequest;
 import konkuk.corkCharge.domain.bookmark.dto.request.PutBookmarkGroupRequest;
-import konkuk.corkCharge.domain.bookmark.dto.response.GetBookmarkGroupDetailResponse;
-import konkuk.corkCharge.domain.bookmark.dto.response.GetBookmarkGroupListResponse;
-import konkuk.corkCharge.domain.bookmark.dto.response.PostBookmarkGroupResponse;
-import konkuk.corkCharge.domain.bookmark.dto.response.PutBookmarkGroupResponse;
+import konkuk.corkCharge.domain.bookmark.dto.response.*;
 import konkuk.corkCharge.domain.bookmark.repository.BookmarkRepository;
 import konkuk.corkCharge.domain.bookmark.repository.RestaurantBookmarkGroupItemRepository;
 import konkuk.corkCharge.domain.bookmark.repository.RestaurantBookmarkGroupRepository;
@@ -309,5 +306,50 @@ public class BookmarkGroupService {
     private String formatCorkagePrice(CorkageStore store) {
         if (store.getCorkagePrice() == null) return null;
         return "병당 " + store.getCorkagePrice() + "원";
+    }
+
+    public GetRestaurantBookmarkGroupListResponse getBookmarkGroupsByRestaurant(
+            User user,
+            Long restaurantId
+    ) {
+        // 유저의 모든 그룹 조회 (정렬 포함)
+        List<RestaurantBookmarkGroup> groups =
+                groupRepository.findAllByUser_UserIdOrderByDisplayOrderAsc(
+                        user.getUserId()
+                );
+
+        // 그룹별 storedFlag + storeCount 계산
+        List<GetRestaurantBookmarkGroupItemResponse> groupResponses =
+                groups.stream()
+                        .map(group -> {
+                            boolean storedFlag =
+                                    restaurantBookmarkGroupItemRepository
+                                            .existsByGroup_IdAndBookmark_TargetTypeAndBookmark_TargetId(
+                                                    group.getId(),
+                                                    BookmarkTargetType.RESTAURANT,
+                                                    restaurantId
+                                            );
+
+                            int storeCount =
+                                    restaurantBookmarkGroupItemRepository.countByGroup_Id(group.getId());
+
+                            return new GetRestaurantBookmarkGroupItemResponse(
+                                    group.getId(),
+                                    group.getName(),
+                                    group.getColor(),
+                                    group.getVisibility(),
+                                    storedFlag,
+                                    storeCount,
+                                    group.getCreatedAt(),
+                                    group.getUpdatedAt()
+                            );
+                        })
+                        .toList();
+
+        // 최종 응답
+        return new GetRestaurantBookmarkGroupListResponse(
+                groupResponses.size(),
+                groupResponses
+        );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#151 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
요청으로 보낸 매장이, 사용자의 그룹 중 어느 것에 포함되어 있는지를 알려주는 api입니다.
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="856" height="660" alt="image" src="https://github.com/user-attachments/assets/524871f2-97ad-4d22-8210-e650336694a9" />
<img width="824" height="449" alt="image" src="https://github.com/user-attachments/assets/0da52b32-57d0-49bc-9111-c90ce0d3be1b" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **New Features**
  * 특정 식당별 북마크 그룹 조회 기능 추가: 사용자가 특정 식당에 저장된 자신의 북마크 그룹 목록을 조회할 수 있습니다. 각 그룹의 이름, 색상, 공개 여부, 저장 상태, 아이템 개수 등의 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->