### PR TITLE
[FIX] 그룹명 기존과 같아도 색상 및 공개여부만 변경 가능하도록 로직 수정

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/bookmark/repository/RestaurantBookmarkGroupRepository.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/repository/RestaurantBookmarkGroupRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface RestaurantBookmarkGroupRepository extends JpaRepository<RestaurantBookmarkGroup, Long> {
     List<RestaurantBookmarkGroup> findAllByIdIn(List<Long> ids);
     boolean existsByUser_UserIdAndName(Long userId, String name);
+    boolean existsByUser_UserIdAndNameAndIdNot(Long userId, String name, Long groupId);
     int countByUser_UserId(Long userId);
     List<RestaurantBookmarkGroup> findAllByUser_UserIdOrderByDisplayOrderAsc(Long userId);
     @Query("""

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
@@ -95,9 +95,9 @@ public class BookmarkGroupService {
             throw new CustomException(BAD_REQUEST);
         }
 
-        // 기존 이름과 완전히 동일한 경우
-        if (group.getName().equals(request.name())) {
-            throw new CustomException(GROUP_NAME_SAME_AS_BEFORE);
+        // 기존의 내용과 전체 동일할 경우에만 예외 터뜨릴 것(name, color, visibility)
+        if (group.getName().equals(request.name()) && group.getColor().equals(request.color()) && group.getVisibility() == request.visibility()) {
+            throw new CustomException(GROUP_CONTENTS_SAME_AS_BEFORE);
         }
 
         // 다른 그룹이 이미 사용 중인 이름인 경우

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
@@ -96,13 +96,14 @@ public class BookmarkGroupService {
         }
 
         // 기존의 내용과 전체 동일할 경우에만 예외 터뜨릴 것(name, color, visibility)
-        if (group.getName().equals(request.name()) && group.getColor().equals(request.color()) && group.getVisibility() == request.visibility()) {
+        if (group.getName().equals(request.name())
+                && group.getColor().equals(request.color())
+                && group.getVisibility() == request.visibility()) {
             throw new CustomException(GROUP_CONTENTS_SAME_AS_BEFORE);
         }
 
-        // TODO 얘가 본인까지도 포함해서 예외 터뜨리는 것 같음.
         // 다른 그룹이 이미 사용 중인 이름인 경우
-        if (groupRepository.existsByUser_UserIdAndName(userId, request.name())) {
+        if (groupRepository.existsByUser_UserIdAndNameAndIdNot(userId, request.name(), groupId)) {
             throw new CustomException(GROUP_NAME_ALREADY_EXISTS);
         }
 

--- a/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
+++ b/src/main/java/konkuk/corkCharge/domain/bookmark/service/BookmarkGroupService.java
@@ -100,6 +100,7 @@ public class BookmarkGroupService {
             throw new CustomException(GROUP_CONTENTS_SAME_AS_BEFORE);
         }
 
+        // TODO 얘가 본인까지도 포함해서 예외 터뜨리는 것 같음.
         // 다른 그룹이 이미 사용 중인 이름인 경우
         if (groupRepository.existsByUser_UserIdAndName(userId, request.name())) {
             throw new CustomException(GROUP_NAME_ALREADY_EXISTS);

--- a/src/main/java/konkuk/corkCharge/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/konkuk/corkCharge/global/response/status/BaseExceptionResponseStatus.java
@@ -69,7 +69,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     GROUP_NOT_FOUND(120001, "해당 북마크 그룹을 찾을 수 없습니다."),
     GROUP_FORBIDDEN(120002, "해당 북마크 그룹에 대한 권한이 없습니다."),
     BOOKMARK_ALREADY_EXISTS(120003, "이미 저장된 매장입니다."),
-    GROUP_NAME_SAME_AS_BEFORE(120004, "기존 그룹명과 동일합니다."),
+    GROUP_CONTENTS_SAME_AS_BEFORE(120004, "기존 그룹 내용과 동일합니다."),
     GROUP_NAME_ALREADY_EXISTS(120005, "이미 존재하는 그룹명입니다."),
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈
#153 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
기존 로직: 이전에 사용하던 그룹명과 동일한 그룹명이 요청에 들어있으면 바로 예외를 터뜨
림 (GROUP_NAME_SAME_AS_BEFORE)
수정된 로직: <그룹명, 색상, 공개여부> 이 3가지가 모두 같은 경우에만 GROUP_CONTENTS_SAME_AS_BEFORE 예외를 터뜨림

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
그룹 생성(그룹명 "결명자차"로 함)
<img width="715" height="672" alt="image" src="https://github.com/user-attachments/assets/879cd2ad-a0f4-497b-a942-713eb0a4e8e1" />

특정 그룹 정보 수정 (그룹명 및 공개여부 동일, 색상만 변경 가능)
<img width="707" height="691" alt="image" src="https://github.com/user-attachments/assets/a3bb566a-f04f-47a0-af16-bbcfe841151a" />

특정 그룹 정보 수정(그룹명 및 색상 동일, 공개여부만 변경 가능)
<img width="705" height="682" alt="image" src="https://github.com/user-attachments/assets/846ec809-17ef-4c37-ad0b-347681299c19" />

특정 그룹 정보 수정(색상 및 공개여부 동일, 그룹명만 변경 가능)
<img width="707" height="690" alt="image" src="https://github.com/user-attachments/assets/bc5d5d9a-bd05-475c-8ea1-174b7ea8b19e" />

특정 그룹 정보 수정(3가지 조건 모두 기존과 동일한 경우 예외처리)
<img width="713" height="633" alt="image" src="https://github.com/user-attachments/assets/61322f0d-e1a3-4d05-8f0c-3887a74f19b8" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 북마크 그룹 업데이트 유효성 검사 개선 - 이름, 색상, 공개 범위 변경을 정확히 감지
* 그룹명 중복 검사 정확성 향상 - 현재 그룹 제외하고 다른 그룹과의 충돌만 감지
* 그룹 업데이트 오류 메시지 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->