### PR TITLE
[FEAT] 매장 데이터 응답 시 운영여부 데이터 추가

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - 'main'
       - 'develope'
-  pull_request:
-    branches:
-      - 'main'
-      - 'develope'
 
 permissions:
   contents: read
@@ -16,6 +12,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ap-northeast-2
+      AWS_DEFAULT_REGION: ap-northeast-2
 
     steps:
       - uses: actions/checkout@v4

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/ClusterListResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/ClusterListResponseMapper.java
@@ -7,7 +7,14 @@ import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
 import konkuk.corkCharge.domain.restaurant.dto.response.GetClusterListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static konkuk.corkCharge.domain.corkageStore.domain.OptionType.ETC;
@@ -31,6 +38,7 @@ public class ClusterListResponseMapper {
                 restaurant.getRating(),
                 restaurant.getReviewCount(),
                 restaurant.getOpeningHours(),
+                getOperationStatus(restaurant.getOpeningHours()),
                 corkagePrice,
                 corkageOptions,
                 imageUrls == null ? new String[0] : imageUrls,
@@ -65,5 +73,139 @@ public class ClusterListResponseMapper {
                 .map(type -> (type == ETC) ? etcContent : type.getLabel())
                 .filter(opt -> opt != null && !opt.isBlank())
                 .toList();
+    }
+
+    private String getOperationStatus(String openingHours) {
+        if (openingHours == null || openingHours.isBlank()) {
+            return "영업종료";
+        }
+
+        Map<String, List<MinuteRange>> schedule = parseSchedule(openingHours);
+        if (schedule.isEmpty()) {
+            return "영업종료";
+        }
+
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        String today = toKorDay(now.getDayOfWeek());
+        String yesterday = toKorDay(now.getDayOfWeek().minus(1));
+        int currentMinute = now.getHour() * 60 + now.getMinute();
+
+        List<MinuteRange> todayRanges = schedule.get(today);
+        if (todayRanges != null && isOpenByTodaySchedule(currentMinute, todayRanges)) {
+            return "운영중";
+        }
+
+        List<MinuteRange> yesterdayRanges = schedule.get(yesterday);
+        if (yesterdayRanges != null && isOpenByYesterdaySchedule(currentMinute, yesterdayRanges)) {
+            return "운영중";
+        }
+
+        return "영업종료";
+    }
+
+    private Map<String, List<MinuteRange>> parseSchedule(String openingHours) {
+        Map<String, List<MinuteRange>> result = new HashMap<>();
+        String[] daySchedules = openingHours.split(",");
+
+        for (String daySchedule : daySchedules) {
+            String[] dayAndTimes = daySchedule.split(":", 2);
+            if (dayAndTimes.length != 2) {
+                continue;
+            }
+
+            String day = dayAndTimes[0].trim();
+            String[] timeSegments = dayAndTimes[1].trim().split("/");
+
+            List<MinuteRange> ranges = new ArrayList<>();
+            for (String segment : timeSegments) {
+                String[] times = segment.trim().split("-", 2);
+                if (times.length != 2) {
+                    continue;
+                }
+
+                Integer start = parseMinute(times[0].trim());
+                Integer end = parseMinute(times[1].trim());
+                if (start == null || end == null) {
+                    continue;
+                }
+                ranges.add(new MinuteRange(start, end));
+            }
+
+            if (!ranges.isEmpty()) {
+                result.put(day, ranges);
+            }
+        }
+
+        return result;
+    }
+
+    private Integer parseMinute(String timeText) {
+        String[] parts = timeText.split(":");
+        if (parts.length != 2) {
+            return null;
+        }
+
+        try {
+            int hour = Integer.parseInt(parts[0]);
+            int minute = Integer.parseInt(parts[1]);
+
+            if (hour == 24 && minute == 0) {
+                return 24 * 60;
+            }
+            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+                return null;
+            }
+
+            return hour * 60 + minute;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private boolean isOpenByTodaySchedule(int nowMinute, List<MinuteRange> ranges) {
+        for (MinuteRange range : ranges) {
+            if (range.is24Hours()) {
+                return true;
+            }
+            if (range.isOvernight()) {
+                if (nowMinute >= range.startMinute()) {
+                    return true;
+                }
+            } else if (nowMinute >= range.startMinute() && nowMinute < range.endMinute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isOpenByYesterdaySchedule(int nowMinute, List<MinuteRange> ranges) {
+        for (MinuteRange range : ranges) {
+            if (range.isOvernight() && nowMinute < range.endMinute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String toKorDay(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+    }
+
+    private record MinuteRange(int startMinute, int endMinute) {
+        private boolean isOvernight() {
+            return endMinute < startMinute;
+        }
+
+        private boolean is24Hours() {
+            return startMinute == endMinute;
+        }
     }
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/ClusterListResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/ClusterListResponseMapper.java
@@ -92,12 +92,12 @@ public class ClusterListResponseMapper {
 
         List<MinuteRange> todayRanges = schedule.get(today);
         if (todayRanges != null && isOpenByTodaySchedule(currentMinute, todayRanges)) {
-            return "운영중";
+            return "영업중";
         }
 
         List<MinuteRange> yesterdayRanges = schedule.get(yesterday);
         if (yesterdayRanges != null && isOpenByYesterdaySchedule(currentMinute, yesterdayRanges)) {
-            return "운영중";
+            return "영업중";
         }
 
         return "영업종료";

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/ClusterListResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/ClusterListResponseMapper.java
@@ -5,16 +5,11 @@ import konkuk.corkCharge.domain.corkageStore.domain.MultiCorkage;
 import konkuk.corkCharge.domain.corkageStore.domain.OptionType;
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
 import konkuk.corkCharge.domain.restaurant.dto.response.GetClusterListResponse;
+import konkuk.corkCharge.domain.restaurant.util.RestaurantOperationStatusResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static konkuk.corkCharge.domain.corkageStore.domain.OptionType.ETC;
@@ -22,6 +17,8 @@ import static konkuk.corkCharge.domain.corkageStore.domain.OptionType.ETC;
 @Component
 @RequiredArgsConstructor
 public class ClusterListResponseMapper {
+
+    private final RestaurantOperationStatusResolver operationStatusResolver;
 
     public GetClusterListResponse.Item toItem(
             Restaurant restaurant,
@@ -38,7 +35,7 @@ public class ClusterListResponseMapper {
                 restaurant.getRating(),
                 restaurant.getReviewCount(),
                 restaurant.getOpeningHours(),
-                getOperationStatus(restaurant.getOpeningHours()),
+                operationStatusResolver.resolve(restaurant.getOpeningHours()),
                 corkagePrice,
                 corkageOptions,
                 imageUrls == null ? new String[0] : imageUrls,
@@ -73,139 +70,5 @@ public class ClusterListResponseMapper {
                 .map(type -> (type == ETC) ? etcContent : type.getLabel())
                 .filter(opt -> opt != null && !opt.isBlank())
                 .toList();
-    }
-
-    private String getOperationStatus(String openingHours) {
-        if (openingHours == null || openingHours.isBlank()) {
-            return "영업종료";
-        }
-
-        Map<String, List<MinuteRange>> schedule = parseSchedule(openingHours);
-        if (schedule.isEmpty()) {
-            return "영업종료";
-        }
-
-        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
-        String today = toKorDay(now.getDayOfWeek());
-        String yesterday = toKorDay(now.getDayOfWeek().minus(1));
-        int currentMinute = now.getHour() * 60 + now.getMinute();
-
-        List<MinuteRange> todayRanges = schedule.get(today);
-        if (todayRanges != null && isOpenByTodaySchedule(currentMinute, todayRanges)) {
-            return "영업중";
-        }
-
-        List<MinuteRange> yesterdayRanges = schedule.get(yesterday);
-        if (yesterdayRanges != null && isOpenByYesterdaySchedule(currentMinute, yesterdayRanges)) {
-            return "영업중";
-        }
-
-        return "영업종료";
-    }
-
-    private Map<String, List<MinuteRange>> parseSchedule(String openingHours) {
-        Map<String, List<MinuteRange>> result = new HashMap<>();
-        String[] daySchedules = openingHours.split(",");
-
-        for (String daySchedule : daySchedules) {
-            String[] dayAndTimes = daySchedule.split(":", 2);
-            if (dayAndTimes.length != 2) {
-                continue;
-            }
-
-            String day = dayAndTimes[0].trim();
-            String[] timeSegments = dayAndTimes[1].trim().split("/");
-
-            List<MinuteRange> ranges = new ArrayList<>();
-            for (String segment : timeSegments) {
-                String[] times = segment.trim().split("-", 2);
-                if (times.length != 2) {
-                    continue;
-                }
-
-                Integer start = parseMinute(times[0].trim());
-                Integer end = parseMinute(times[1].trim());
-                if (start == null || end == null) {
-                    continue;
-                }
-                ranges.add(new MinuteRange(start, end));
-            }
-
-            if (!ranges.isEmpty()) {
-                result.put(day, ranges);
-            }
-        }
-
-        return result;
-    }
-
-    private Integer parseMinute(String timeText) {
-        String[] parts = timeText.split(":");
-        if (parts.length != 2) {
-            return null;
-        }
-
-        try {
-            int hour = Integer.parseInt(parts[0]);
-            int minute = Integer.parseInt(parts[1]);
-
-            if (hour == 24 && minute == 0) {
-                return 24 * 60;
-            }
-            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
-                return null;
-            }
-
-            return hour * 60 + minute;
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    private boolean isOpenByTodaySchedule(int nowMinute, List<MinuteRange> ranges) {
-        for (MinuteRange range : ranges) {
-            if (range.is24Hours()) {
-                return true;
-            }
-            if (range.isOvernight()) {
-                if (nowMinute >= range.startMinute()) {
-                    return true;
-                }
-            } else if (nowMinute >= range.startMinute() && nowMinute < range.endMinute()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isOpenByYesterdaySchedule(int nowMinute, List<MinuteRange> ranges) {
-        for (MinuteRange range : ranges) {
-            if (range.isOvernight() && nowMinute < range.endMinute()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private String toKorDay(DayOfWeek dayOfWeek) {
-        return switch (dayOfWeek) {
-            case MONDAY -> "월";
-            case TUESDAY -> "화";
-            case WEDNESDAY -> "수";
-            case THURSDAY -> "목";
-            case FRIDAY -> "금";
-            case SATURDAY -> "토";
-            case SUNDAY -> "일";
-        };
-    }
-
-    private record MinuteRange(int startMinute, int endMinute) {
-        private boolean isOvernight() {
-            return endMinute < startMinute;
-        }
-
-        private boolean is24Hours() {
-            return startMinute == endMinute;
-        }
     }
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/HomeRestaurantResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/HomeRestaurantResponseMapper.java
@@ -3,21 +3,20 @@ package konkuk.corkCharge.domain.restaurant.dto.mapper;
 import konkuk.corkCharge.domain.corkageStore.domain.OptionType;
 import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
 import konkuk.corkCharge.domain.restaurant.dto.response.GetHomeRestaurantResponse;
+import konkuk.corkCharge.domain.restaurant.util.RestaurantOperationStatusResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static konkuk.corkCharge.domain.corkageStore.domain.OptionType.ETC;
 
 @Component
+@RequiredArgsConstructor
 public class HomeRestaurantResponseMapper {
+
+    private final RestaurantOperationStatusResolver operationStatusResolver;
 
     public GetHomeRestaurantResponse toResponse(
             RestaurantSummary summary,
@@ -37,7 +36,7 @@ public class HomeRestaurantResponseMapper {
                 distanceKm,
                 summary.getMainImageUrl(),
                 summary.getOpeningHours(),
-                getOperationStatus(summary.getOpeningHours()),
+                operationStatusResolver.resolve(summary.getOpeningHours()),
                 summary.getBookmarkCount(),
                 scrap
         );
@@ -54,139 +53,5 @@ public class HomeRestaurantResponseMapper {
                 .map(type -> type == ETC ? etcContent : type.getLabel())
                 .filter(opt -> opt != null && !opt.isBlank())
                 .toList();
-    }
-
-    private String getOperationStatus(String openingHours) {
-        if (openingHours == null || openingHours.isBlank()) {
-            return "영업종료";
-        }
-
-        Map<String, List<MinuteRange>> schedule = parseSchedule(openingHours);
-        if (schedule.isEmpty()) {
-            return "영업종료";
-        }
-
-        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
-        String today = toKorDay(now.getDayOfWeek());
-        String yesterday = toKorDay(now.getDayOfWeek().minus(1));
-        int currentMinute = now.getHour() * 60 + now.getMinute();
-
-        List<MinuteRange> todayRanges = schedule.get(today);
-        if (todayRanges != null && isOpenByTodaySchedule(currentMinute, todayRanges)) {
-            return "운영중";
-        }
-
-        List<MinuteRange> yesterdayRanges = schedule.get(yesterday);
-        if (yesterdayRanges != null && isOpenByYesterdaySchedule(currentMinute, yesterdayRanges)) {
-            return "운영중";
-        }
-
-        return "영업종료";
-    }
-
-    private Map<String, List<MinuteRange>> parseSchedule(String openingHours) {
-        Map<String, List<MinuteRange>> result = new HashMap<>();
-        String[] daySchedules = openingHours.split(",");
-
-        for (String daySchedule : daySchedules) {
-            String[] dayAndTimes = daySchedule.split(":", 2);
-            if (dayAndTimes.length != 2) {
-                continue;
-            }
-
-            String day = dayAndTimes[0].trim();
-            String[] timeSegments = dayAndTimes[1].trim().split("/");
-
-            List<MinuteRange> ranges = new ArrayList<>();
-            for (String segment : timeSegments) {
-                String[] times = segment.trim().split("-", 2);
-                if (times.length != 2) {
-                    continue;
-                }
-
-                Integer start = parseMinute(times[0].trim());
-                Integer end = parseMinute(times[1].trim());
-                if (start == null || end == null) {
-                    continue;
-                }
-                ranges.add(new MinuteRange(start, end));
-            }
-
-            if (!ranges.isEmpty()) {
-                result.put(day, ranges);
-            }
-        }
-
-        return result;
-    }
-
-    private Integer parseMinute(String timeText) {
-        String[] parts = timeText.split(":");
-        if (parts.length != 2) {
-            return null;
-        }
-
-        try {
-            int hour = Integer.parseInt(parts[0]);
-            int minute = Integer.parseInt(parts[1]);
-
-            if (hour == 24 && minute == 0) {
-                return 24 * 60;
-            }
-            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
-                return null;
-            }
-
-            return hour * 60 + minute;
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    private boolean isOpenByTodaySchedule(int nowMinute, List<MinuteRange> ranges) {
-        for (MinuteRange range : ranges) {
-            if (range.is24Hours()) {
-                return true;
-            }
-            if (range.isOvernight()) {
-                if (nowMinute >= range.startMinute()) {
-                    return true;
-                }
-            } else if (nowMinute >= range.startMinute() && nowMinute < range.endMinute()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isOpenByYesterdaySchedule(int nowMinute, List<MinuteRange> ranges) {
-        for (MinuteRange range : ranges) {
-            if (range.isOvernight() && nowMinute < range.endMinute()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private String toKorDay(DayOfWeek dayOfWeek) {
-        return switch (dayOfWeek) {
-            case MONDAY -> "월";
-            case TUESDAY -> "화";
-            case WEDNESDAY -> "수";
-            case THURSDAY -> "목";
-            case FRIDAY -> "금";
-            case SATURDAY -> "토";
-            case SUNDAY -> "일";
-        };
-    }
-
-    private record MinuteRange(int startMinute, int endMinute) {
-        private boolean isOvernight() {
-            return endMinute < startMinute;
-        }
-
-        private boolean is24Hours() {
-            return startMinute == endMinute;
-        }
     }
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/HomeRestaurantResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/HomeRestaurantResponseMapper.java
@@ -5,7 +5,13 @@ import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
 import konkuk.corkCharge.domain.restaurant.dto.response.GetHomeRestaurantResponse;
 import org.springframework.stereotype.Component;
 
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static konkuk.corkCharge.domain.corkageStore.domain.OptionType.ETC;
@@ -31,6 +37,7 @@ public class HomeRestaurantResponseMapper {
                 distanceKm,
                 summary.getMainImageUrl(),
                 summary.getOpeningHours(),
+                getOperationStatus(summary.getOpeningHours()),
                 summary.getBookmarkCount(),
                 scrap
         );
@@ -49,4 +56,137 @@ public class HomeRestaurantResponseMapper {
                 .toList();
     }
 
+    private String getOperationStatus(String openingHours) {
+        if (openingHours == null || openingHours.isBlank()) {
+            return "영업종료";
+        }
+
+        Map<String, List<MinuteRange>> schedule = parseSchedule(openingHours);
+        if (schedule.isEmpty()) {
+            return "영업종료";
+        }
+
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        String today = toKorDay(now.getDayOfWeek());
+        String yesterday = toKorDay(now.getDayOfWeek().minus(1));
+        int currentMinute = now.getHour() * 60 + now.getMinute();
+
+        List<MinuteRange> todayRanges = schedule.get(today);
+        if (todayRanges != null && isOpenByTodaySchedule(currentMinute, todayRanges)) {
+            return "운영중";
+        }
+
+        List<MinuteRange> yesterdayRanges = schedule.get(yesterday);
+        if (yesterdayRanges != null && isOpenByYesterdaySchedule(currentMinute, yesterdayRanges)) {
+            return "운영중";
+        }
+
+        return "영업종료";
+    }
+
+    private Map<String, List<MinuteRange>> parseSchedule(String openingHours) {
+        Map<String, List<MinuteRange>> result = new HashMap<>();
+        String[] daySchedules = openingHours.split(",");
+
+        for (String daySchedule : daySchedules) {
+            String[] dayAndTimes = daySchedule.split(":", 2);
+            if (dayAndTimes.length != 2) {
+                continue;
+            }
+
+            String day = dayAndTimes[0].trim();
+            String[] timeSegments = dayAndTimes[1].trim().split("/");
+
+            List<MinuteRange> ranges = new ArrayList<>();
+            for (String segment : timeSegments) {
+                String[] times = segment.trim().split("-", 2);
+                if (times.length != 2) {
+                    continue;
+                }
+
+                Integer start = parseMinute(times[0].trim());
+                Integer end = parseMinute(times[1].trim());
+                if (start == null || end == null) {
+                    continue;
+                }
+                ranges.add(new MinuteRange(start, end));
+            }
+
+            if (!ranges.isEmpty()) {
+                result.put(day, ranges);
+            }
+        }
+
+        return result;
+    }
+
+    private Integer parseMinute(String timeText) {
+        String[] parts = timeText.split(":");
+        if (parts.length != 2) {
+            return null;
+        }
+
+        try {
+            int hour = Integer.parseInt(parts[0]);
+            int minute = Integer.parseInt(parts[1]);
+
+            if (hour == 24 && minute == 0) {
+                return 24 * 60;
+            }
+            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+                return null;
+            }
+
+            return hour * 60 + minute;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private boolean isOpenByTodaySchedule(int nowMinute, List<MinuteRange> ranges) {
+        for (MinuteRange range : ranges) {
+            if (range.is24Hours()) {
+                return true;
+            }
+            if (range.isOvernight()) {
+                if (nowMinute >= range.startMinute()) {
+                    return true;
+                }
+            } else if (nowMinute >= range.startMinute() && nowMinute < range.endMinute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isOpenByYesterdaySchedule(int nowMinute, List<MinuteRange> ranges) {
+        for (MinuteRange range : ranges) {
+            if (range.isOvernight() && nowMinute < range.endMinute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String toKorDay(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+    }
+
+    private record MinuteRange(int startMinute, int endMinute) {
+        private boolean isOvernight() {
+            return endMinute < startMinute;
+        }
+
+        private boolean is24Hours() {
+            return startMinute == endMinute;
+        }
+    }
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/RestaurantDetailResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/RestaurantDetailResponseMapper.java
@@ -3,20 +3,18 @@ package konkuk.corkCharge.domain.restaurant.dto.mapper;
 import konkuk.corkCharge.domain.corkageStore.domain.OptionType;
 import konkuk.corkCharge.domain.restaurant.domain.RestaurantSummary;
 import konkuk.corkCharge.domain.restaurant.dto.response.GetRestaurantDetailResponse;
+import konkuk.corkCharge.domain.restaurant.util.RestaurantOperationStatusResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class RestaurantDetailResponseMapper {
+
+    private final RestaurantOperationStatusResolver operationStatusResolver;
 
     public GetRestaurantDetailResponse toResponse(RestaurantSummary summary, boolean scrap) {
 
@@ -46,7 +44,7 @@ public class RestaurantDetailResponseMapper {
                 summary.getPairingDescription(),
                 summary.getPairingImageUrl(),
                 summary.getOpeningHours(),
-                getOperationStatus(summary.getOpeningHours()),
+                operationStatusResolver.resolve(summary.getOpeningHours()),
                 scrap
         );
     }
@@ -73,139 +71,5 @@ public class RestaurantDetailResponseMapper {
         }
 
         return result;
-    }
-
-    private String getOperationStatus(String openingHours) {
-        if (openingHours == null || openingHours.isBlank()) {
-            return "영업종료";
-        }
-
-        Map<String, List<MinuteRange>> schedule = parseSchedule(openingHours);
-        if (schedule.isEmpty()) {
-            return "영업종료";
-        }
-
-        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
-        String today = toKorDay(now.getDayOfWeek());
-        String yesterday = toKorDay(now.getDayOfWeek().minus(1));
-        int currentMinute = now.getHour() * 60 + now.getMinute();
-
-        List<MinuteRange> todayRanges = schedule.get(today);
-        if (todayRanges != null && isOpenByTodaySchedule(currentMinute, todayRanges)) {
-            return "영영중";
-        }
-
-        List<MinuteRange> yesterdayRanges = schedule.get(yesterday);
-        if (yesterdayRanges != null && isOpenByYesterdaySchedule(currentMinute, yesterdayRanges)) {
-            return "영영중";
-        }
-
-        return "영업종료";
-    }
-
-    private Map<String, List<MinuteRange>> parseSchedule(String openingHours) {
-        Map<String, List<MinuteRange>> result = new HashMap<>();
-        String[] daySchedules = openingHours.split(",");
-
-        for (String daySchedule : daySchedules) {
-            String[] dayAndTimes = daySchedule.split(":", 2);
-            if (dayAndTimes.length != 2) {
-                continue;
-            }
-
-            String day = dayAndTimes[0].trim();
-            String[] timeSegments = dayAndTimes[1].trim().split("/");
-
-            List<MinuteRange> ranges = new ArrayList<>();
-            for (String segment : timeSegments) {
-                String[] times = segment.trim().split("-", 2);
-                if (times.length != 2) {
-                    continue;
-                }
-
-                Integer start = parseMinute(times[0].trim());
-                Integer end = parseMinute(times[1].trim());
-                if (start == null || end == null) {
-                    continue;
-                }
-                ranges.add(new MinuteRange(start, end));
-            }
-
-            if (!ranges.isEmpty()) {
-                result.put(day, ranges);
-            }
-        }
-
-        return result;
-    }
-
-    private Integer parseMinute(String timeText) {
-        String[] parts = timeText.split(":");
-        if (parts.length != 2) {
-            return null;
-        }
-
-        try {
-            int hour = Integer.parseInt(parts[0]);
-            int minute = Integer.parseInt(parts[1]);
-
-            if (hour == 24 && minute == 0) {
-                return 24 * 60;
-            }
-            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
-                return null;
-            }
-
-            return hour * 60 + minute;
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    private boolean isOpenByTodaySchedule(int nowMinute, List<MinuteRange> ranges) {
-        for (MinuteRange range : ranges) {
-            if (range.is24Hours()) {
-                return true;
-            }
-            if (range.isOvernight()) {
-                if (nowMinute >= range.startMinute()) {
-                    return true;
-                }
-            } else if (nowMinute >= range.startMinute() && nowMinute < range.endMinute()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isOpenByYesterdaySchedule(int nowMinute, List<MinuteRange> ranges) {
-        for (MinuteRange range : ranges) {
-            if (range.isOvernight() && nowMinute < range.endMinute()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private String toKorDay(DayOfWeek dayOfWeek) {
-        return switch (dayOfWeek) {
-            case MONDAY -> "월";
-            case TUESDAY -> "화";
-            case WEDNESDAY -> "수";
-            case THURSDAY -> "목";
-            case FRIDAY -> "금";
-            case SATURDAY -> "토";
-            case SUNDAY -> "일";
-        };
-    }
-
-    private record MinuteRange(int startMinute, int endMinute) {
-        private boolean isOvernight() {
-            return endMinute < startMinute;
-        }
-
-        private boolean is24Hours() {
-            return startMinute == endMinute;
-        }
     }
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/RestaurantDetailResponseMapper.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/mapper/RestaurantDetailResponseMapper.java
@@ -6,8 +6,13 @@ import konkuk.corkCharge.domain.restaurant.dto.response.GetRestaurantDetailRespo
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -41,6 +46,7 @@ public class RestaurantDetailResponseMapper {
                 summary.getPairingDescription(),
                 summary.getPairingImageUrl(),
                 summary.getOpeningHours(),
+                getOperationStatus(summary.getOpeningHours()),
                 scrap
         );
     }
@@ -67,5 +73,139 @@ public class RestaurantDetailResponseMapper {
         }
 
         return result;
+    }
+
+    private String getOperationStatus(String openingHours) {
+        if (openingHours == null || openingHours.isBlank()) {
+            return "영업종료";
+        }
+
+        Map<String, List<MinuteRange>> schedule = parseSchedule(openingHours);
+        if (schedule.isEmpty()) {
+            return "영업종료";
+        }
+
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        String today = toKorDay(now.getDayOfWeek());
+        String yesterday = toKorDay(now.getDayOfWeek().minus(1));
+        int currentMinute = now.getHour() * 60 + now.getMinute();
+
+        List<MinuteRange> todayRanges = schedule.get(today);
+        if (todayRanges != null && isOpenByTodaySchedule(currentMinute, todayRanges)) {
+            return "영영중";
+        }
+
+        List<MinuteRange> yesterdayRanges = schedule.get(yesterday);
+        if (yesterdayRanges != null && isOpenByYesterdaySchedule(currentMinute, yesterdayRanges)) {
+            return "영영중";
+        }
+
+        return "영업종료";
+    }
+
+    private Map<String, List<MinuteRange>> parseSchedule(String openingHours) {
+        Map<String, List<MinuteRange>> result = new HashMap<>();
+        String[] daySchedules = openingHours.split(",");
+
+        for (String daySchedule : daySchedules) {
+            String[] dayAndTimes = daySchedule.split(":", 2);
+            if (dayAndTimes.length != 2) {
+                continue;
+            }
+
+            String day = dayAndTimes[0].trim();
+            String[] timeSegments = dayAndTimes[1].trim().split("/");
+
+            List<MinuteRange> ranges = new ArrayList<>();
+            for (String segment : timeSegments) {
+                String[] times = segment.trim().split("-", 2);
+                if (times.length != 2) {
+                    continue;
+                }
+
+                Integer start = parseMinute(times[0].trim());
+                Integer end = parseMinute(times[1].trim());
+                if (start == null || end == null) {
+                    continue;
+                }
+                ranges.add(new MinuteRange(start, end));
+            }
+
+            if (!ranges.isEmpty()) {
+                result.put(day, ranges);
+            }
+        }
+
+        return result;
+    }
+
+    private Integer parseMinute(String timeText) {
+        String[] parts = timeText.split(":");
+        if (parts.length != 2) {
+            return null;
+        }
+
+        try {
+            int hour = Integer.parseInt(parts[0]);
+            int minute = Integer.parseInt(parts[1]);
+
+            if (hour == 24 && minute == 0) {
+                return 24 * 60;
+            }
+            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+                return null;
+            }
+
+            return hour * 60 + minute;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private boolean isOpenByTodaySchedule(int nowMinute, List<MinuteRange> ranges) {
+        for (MinuteRange range : ranges) {
+            if (range.is24Hours()) {
+                return true;
+            }
+            if (range.isOvernight()) {
+                if (nowMinute >= range.startMinute()) {
+                    return true;
+                }
+            } else if (nowMinute >= range.startMinute() && nowMinute < range.endMinute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isOpenByYesterdaySchedule(int nowMinute, List<MinuteRange> ranges) {
+        for (MinuteRange range : ranges) {
+            if (range.isOvernight() && nowMinute < range.endMinute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String toKorDay(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+    }
+
+    private record MinuteRange(int startMinute, int endMinute) {
+        private boolean isOvernight() {
+            return endMinute < startMinute;
+        }
+
+        private boolean is24Hours() {
+            return startMinute == endMinute;
+        }
     }
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetClusterListResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetClusterListResponse.java
@@ -12,6 +12,7 @@ public record GetClusterListResponse(
             Double rating,
             int reviewCount,
             String openingHours,
+            String operationStatus,
             String corkagePrice,
             List<String> corkageOptions,
             String[] imageUrls,

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetHomeRestaurantResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetHomeRestaurantResponse.java
@@ -13,6 +13,7 @@ public record GetHomeRestaurantResponse(
         Double distance,          // km기준, lat/lon 없으면 null
         String mainImageUrls,
         String openingHours,
+        String operationStatus,
         Integer bookmarkCount,
         boolean scrap
 ) {

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetRestaurantDetailResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/dto/response/GetRestaurantDetailResponse.java
@@ -18,6 +18,7 @@ public record GetRestaurantDetailResponse(
         String pairingDescription,
         String pairingImageUrl,
         String openingHours,
+        String operationStatus,
         boolean scrap
 ) {
 }

--- a/src/main/java/konkuk/corkCharge/domain/restaurant/util/RestaurantOperationStatusResolver.java
+++ b/src/main/java/konkuk/corkCharge/domain/restaurant/util/RestaurantOperationStatusResolver.java
@@ -1,0 +1,151 @@
+package konkuk.corkCharge.domain.restaurant.util;
+
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class RestaurantOperationStatusResolver {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    public String resolve(String openingHours) {
+        if (openingHours == null || openingHours.isBlank()) {
+            return "영업종료";
+        }
+
+        Map<String, List<MinuteRange>> schedule = parseSchedule(openingHours);
+        if (schedule.isEmpty()) {
+            return "영업종료";
+        }
+
+        LocalDateTime now = LocalDateTime.now(KST);
+        String today = toKorDay(now.getDayOfWeek());
+        String yesterday = toKorDay(now.getDayOfWeek().minus(1));
+        int currentMinute = now.getHour() * 60 + now.getMinute();
+
+        List<MinuteRange> todayRanges = schedule.get(today);
+        if (todayRanges != null && isOpenByTodaySchedule(currentMinute, todayRanges)) {
+            return "영업중";
+        }
+
+        List<MinuteRange> yesterdayRanges = schedule.get(yesterday);
+        if (yesterdayRanges != null && isOpenByYesterdaySchedule(currentMinute, yesterdayRanges)) {
+            return "영업중";
+        }
+
+        return "영업종료";
+    }
+
+    private Map<String, List<MinuteRange>> parseSchedule(String openingHours) {
+        Map<String, List<MinuteRange>> result = new HashMap<>();
+        String[] daySchedules = openingHours.split(",");
+
+        for (String daySchedule : daySchedules) {
+            String[] dayAndTimes = daySchedule.split(":", 2);
+            if (dayAndTimes.length != 2) {
+                continue;
+            }
+
+            String day = dayAndTimes[0].trim();
+            String[] timeSegments = dayAndTimes[1].trim().split("/");
+
+            List<MinuteRange> ranges = new ArrayList<>();
+            for (String segment : timeSegments) {
+                String[] times = segment.trim().split("-", 2);
+                if (times.length != 2) {
+                    continue;
+                }
+
+                Integer start = parseMinute(times[0].trim());
+                Integer end = parseMinute(times[1].trim());
+                if (start == null || end == null) {
+                    continue;
+                }
+                ranges.add(new MinuteRange(start, end));
+            }
+
+            if (!ranges.isEmpty()) {
+                result.put(day, ranges);
+            }
+        }
+
+        return result;
+    }
+
+    private Integer parseMinute(String timeText) {
+        String[] parts = timeText.split(":");
+        if (parts.length != 2) {
+            return null;
+        }
+
+        try {
+            int hour = Integer.parseInt(parts[0]);
+            int minute = Integer.parseInt(parts[1]);
+
+            if (hour == 24 && minute == 0) {
+                return 24 * 60;
+            }
+            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+                return null;
+            }
+
+            return hour * 60 + minute;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private boolean isOpenByTodaySchedule(int nowMinute, List<MinuteRange> ranges) {
+        for (MinuteRange range : ranges) {
+            if (range.is24Hours()) {
+                return true;
+            }
+            if (range.isOvernight()) {
+                if (nowMinute >= range.startMinute()) {
+                    return true;
+                }
+            } else if (nowMinute >= range.startMinute() && nowMinute < range.endMinute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isOpenByYesterdaySchedule(int nowMinute, List<MinuteRange> ranges) {
+        for (MinuteRange range : ranges) {
+            if (range.isOvernight() && nowMinute < range.endMinute()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String toKorDay(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+    }
+
+    private record MinuteRange(int startMinute, int endMinute) {
+        private boolean isOvernight() {
+            return endMinute < startMinute;
+        }
+
+        private boolean is24Hours() {
+            return startMinute == endMinute;
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈 화면 레스토랑 목록 응답에 영업 상태(operationStatus)를 추가했습니다.
  * 클러스터(지도/그룹) 목록 응답에도 영업 상태가 표시됩니다.
  * 상세 정보 응답에 영업 상태가 포함되어 현재 영업 중/영업 종료 여부를 즉시 확인할 수 있습니다.
  * 야간 및 24시간 영업 판별이 향상되어 더 정확한 상태를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->