### PR TITLE
[REFACTOR] 토큰 에러 발생 시 리다이렉트(302)에서 401로 응답

### DIFF
--- a/src/main/java/konkuk/corkCharge/global/config/SecurityConfig.java
+++ b/src/main/java/konkuk/corkCharge/global/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -64,6 +66,10 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(o -> o.userInfoEndpoint(u -> u.userService(oAuthService)))
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+                )
                 .addFilterBefore(jwtFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);
 
         return http.build();


### PR DESCRIPTION
## #️⃣연관된 이슈

#156 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 실패 시 시스템이 명시적인 401 Unauthorized 오류 응답을 반환하도록 개선되었습니다. 이전의 기본 동작에서 보다 명확한 오류 처리로 변경되어 인증 관련 오류 상황에서 더 나은 에러 응답이 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->