### PR TITLE
[REFACTOR] users/page의 리뷰 부분 응답을 review/home과 같도록 수정

### DIFF
--- a/src/main/java/konkuk/corkCharge/domain/user/dto/response/GetMyPageResponse.java
+++ b/src/main/java/konkuk/corkCharge/domain/user/dto/response/GetMyPageResponse.java
@@ -1,12 +1,12 @@
 package konkuk.corkCharge.domain.user.dto.response;
 
-import konkuk.corkCharge.domain.review.dto.response.GetMyPageReviewResponse;
+import konkuk.corkCharge.domain.review.dto.response.GetHomeCorkageReviewResponse;
 
 import java.util.List;
 
 public record GetMyPageResponse(
         String nickname,
         String email,
-        List<GetMyPageReviewResponse> reviews
+        List<GetHomeCorkageReviewResponse> reviews
 ) {
 }

--- a/src/main/java/konkuk/corkCharge/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/corkCharge/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import konkuk.corkCharge.domain.image.repository.ImageRepository;
 import konkuk.corkCharge.domain.image.service.S3ImageService;
 import konkuk.corkCharge.domain.restaurant.domain.Restaurant;
 import konkuk.corkCharge.domain.review.domain.Review;
+import konkuk.corkCharge.domain.review.dto.response.GetHomeCorkageReviewResponse;
 import konkuk.corkCharge.domain.review.dto.response.GetMyPageReviewResponse;
 import konkuk.corkCharge.domain.review.repository.ReviewRepository;
 import konkuk.corkCharge.domain.user.domain.Role;
@@ -93,18 +94,25 @@ public class UserService {
 
         List<Review> reviews = reviewRepository.findAllByUser_UserId(userId);
 
-        List<GetMyPageReviewResponse> reviewDtos = reviews.stream()
+        List<GetHomeCorkageReviewResponse> reviewDtos = reviews.stream()
                 .map(review -> {
                     Restaurant restaurant = review.getRestaurant();
-                    String thumbnailUrl = imageRepository
-                            .findFirstByCategoryAndTypeIdOrderByCreatedAtAsc(REVIEW, review.getReviewId())
-                            .map(Image::getImageUrl)
-                            .orElse(null);
 
-                    return new GetMyPageReviewResponse(
+                    List<String> imageUrls = imageRepository
+                            .findAllByCategoryAndTypeId(REVIEW, review.getReviewId())
+                            .stream()
+                            .map(Image::getImageUrl)
+                            .toList();
+
+                    return new GetHomeCorkageReviewResponse(
+                            review.getReviewId(),
+                            restaurant.getRestaurantId(),
                             restaurant.getName(),
-                            restaurant.getAddress(),
-                            thumbnailUrl
+                            user.getName(),
+                            review.getContent(),
+                            review.getRating(),
+                            review.getCreatedAt(),
+                            imageUrls
                     );
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#158 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
review/home에서 사용하는 응답 dto를 users/page의 reivew 부분 리스트에서 포맷으로 사용하도록 수정하였습니다.

### 스크린샷 (선택)
users/page
<img width="708" height="649" alt="image" src="https://github.com/user-attachments/assets/82886ae7-1d5c-44cf-9151-bf869c692760" />

review/home
<img width="704" height="606" alt="image" src="https://github.com/user-attachments/assets/53a24e0a-b43a-47d9-b9a6-3e1b71e3c13a" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * 마이페이지의 리뷰 섹션에서 각 리뷰마다 모든 첨부 이미지를 표시하도록 개선되었습니다. 함께 제공되는 리뷰 정보도 더욱 충실해졌습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CorkCharge/CorkCharge-BE/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->